### PR TITLE
feat: Literal Functions Compliation

### DIFF
--- a/src/virtual-machine/compiler/environment.ts
+++ b/src/virtual-machine/compiler/environment.ts
@@ -27,6 +27,9 @@ class CompileEnvironment {
 
   declare_var(name: string) {
     const frame_idx = this.frames.length - 1
+    for (const var_name of this.frames[frame_idx]) {
+      if (var_name === name) throw Error('Variable already declared')
+    }
     const new_len = this.frames[frame_idx].push(name)
     return [frame_idx, new_len - 1]
   }

--- a/src/virtual-machine/compiler/instructions/block.ts
+++ b/src/virtual-machine/compiler/instructions/block.ts
@@ -15,15 +15,17 @@ export class BlockInstruction extends Instruction {
     this.frame = [...frame]
   }
 }
+export class FuncBlockInstruction extends BlockInstruction {
+  args: number
+  constructor(args: number) {
+    super(false)
+    this.tag = 'FUNC_BLOCK'
+    this.args = args
+  }
+}
 
 export class ExitBlockInstruction extends Instruction {
   constructor() {
     super('EXIT_BLOCK')
-  }
-}
-
-export class ReturnInstruction extends Instruction {
-  constructor() {
-    super('RETURN')
   }
 }

--- a/src/virtual-machine/compiler/instructions/funcs.ts
+++ b/src/virtual-machine/compiler/instructions/funcs.ts
@@ -1,0 +1,35 @@
+import { Instruction } from './base'
+
+export class LoadFuncInstruction extends Instruction {
+  PC: number
+  constructor(PC: number) {
+    super('LF')
+    this.PC = PC
+  }
+
+  static is(instr: Instruction): instr is LoadFuncInstruction {
+    return instr.tag === 'LF'
+  }
+}
+
+export class CallInstruction extends Instruction {
+  args: number
+  constructor(args: number) {
+    super('CALL')
+    this.args = args
+  }
+
+  static is(instr: Instruction): instr is CallInstruction {
+    return instr.tag === 'CALL'
+  }
+}
+
+export class ReturnInstruction extends Instruction {
+  constructor() {
+    super('RET')
+  }
+
+  static is(instr: Instruction): instr is ReturnInstruction {
+    return instr.tag === 'RET'
+  }
+}

--- a/src/virtual-machine/compiler/instructions/index.ts
+++ b/src/virtual-machine/compiler/instructions/index.ts
@@ -1,5 +1,7 @@
 export * from './base'
 export * from './block'
+export * from './control'
+export * from './funcs'
 export * from './load'
 export * from './operator'
 export * from './store'

--- a/src/virtual-machine/executor/process.ts
+++ b/src/virtual-machine/executor/process.ts
@@ -132,6 +132,7 @@ export class Process {
           this.context.E().extend_env(new_frame.addr, instr.for_block).addr,
         )
       } else {
+        // This is to not trigger the exit scope condition of the closure env
         this.context.set_E(
           this.context.E().extend_env(new_frame.addr, instr.for_block).addr,
         )

--- a/src/virtual-machine/executor/process.ts
+++ b/src/virtual-machine/executor/process.ts
@@ -1,11 +1,17 @@
 import {
   BinaryInstruction,
   BlockInstruction,
+  CallInstruction,
   DataType,
   DoneInstruction,
   ExitBlockInstruction,
+  ExitLoopInstruction,
+  FuncBlockInstruction,
   Instruction,
+  JumpIfFalseInstruction,
+  JumpInstruction,
   LoadConstantInstruction,
+  LoadFuncInstruction,
   LoadVariableInstruction,
   PopInstruction,
   ReturnInstruction,
@@ -13,19 +19,16 @@ import {
   UnaryInstruction,
 } from '../compiler/instructions'
 import {
-  ExitLoopInstruction,
-  JumpIfFalseInstruction,
-  JumpInstruction,
-} from '../compiler/instructions/control'
-import {
   BoolType,
   Float64Type,
+  FunctionType,
   Int64Type,
   StringType,
 } from '../compiler/typing'
 import { Heap } from '../heap'
 import { ContextNode } from '../heap/types/context'
 import { EnvironmentNode, FrameNode } from '../heap/types/environment'
+import { CallRefNode, FuncNode } from '../heap/types/func'
 import {
   BoolNode,
   FloatNode,
@@ -48,13 +51,19 @@ export class Process {
   }
 
   start() {
+    // Note this is to simulate the main function as a func call
+    const global_env = this.context.E().addr
+    this.context.pushRTS(
+      CallRefNode.create(this.instructions.length - 1, this.heap).addr,
+    )
+    this.context.pushRTS(global_env)
     let runtime_count = 0
     while (!DoneInstruction.is(this.instructions[this.context.PC()])) {
       const instr = this.instructions[this.context.incr_PC()]
-      //   console.log('Instr:', instr)
+      // console.log('Instr:', instr)
       this.execute_microcode(instr)
       //   this.context.printOS()
-      //   this.context.printRTS()
+      // this.context.printRTS()
       runtime_count += 1
       if (runtime_count > 10 ** 5) throw Error('Time Limit Exceeded!')
     }
@@ -102,7 +111,6 @@ export class Process {
       const src = this.context.popOS()
       this.heap.copy(dst, src)
     } else if (instr instanceof BlockInstruction) {
-      this.context.pushRTS(this.context.E().addr)
       const new_frame = FrameNode.create(instr.frame.length, this.heap)
       this.heap.temp_roots.push(new_frame.addr)
       for (let i = 0; i < instr.frame.length; i++) {
@@ -115,12 +123,29 @@ export class Process {
           new_frame.set_idx(FloatNode.default(this.heap).addr, i)
         } else if (T instanceof StringType) {
           new_frame.set_idx(StringNode.default(this.heap).addr, i)
+        } else if (T instanceof FunctionType) {
+          new_frame.set_idx(FuncNode.default(this.heap).addr, i)
         } else throw Error('Unsupported Type')
       }
-      this.context.set_E(
-        this.context.E().extend_env(new_frame.addr, instr.for_block).addr,
-      )
+      if (!(instr instanceof FuncBlockInstruction)) {
+        this.context.pushRTS(
+          this.context.E().extend_env(new_frame.addr, instr.for_block).addr,
+        )
+      } else {
+        this.context.set_E(
+          this.context.E().extend_env(new_frame.addr, instr.for_block).addr,
+        )
+      }
       this.heap.temp_roots.pop()
+      if (instr instanceof FuncBlockInstruction) {
+        for (let i = instr.args - 1; i >= 0; i--) {
+          const src = this.context.popOS()
+          const dst = new_frame.get_idx(i)
+          this.heap.copy(dst, src)
+        }
+        // Pop function in stack
+        this.context.popOS()
+      }
     } else if (instr instanceof ExitBlockInstruction) {
       this.context.popRTS()
       // TODO: Implement defer in popRTS
@@ -130,15 +155,33 @@ export class Process {
       ).get_value()
       if (!pred) this.context.set_PC(instr.addr)
     } else if (instr instanceof ExitLoopInstruction) {
-      while (!this.context.E().if_for_block()) {
+      while (this.context.E().if_for_block()) {
         // TODO: Implement defer in popRTS
         this.context.popRTS()
       }
       this.context.set_PC(instr.addr)
     } else if (instr instanceof JumpInstruction) {
       this.context.set_PC(instr.addr)
+    } else if (instr instanceof LoadFuncInstruction) {
+      this.context.pushOS(
+        FuncNode.create(instr.PC, this.context.E().addr, this.heap).addr,
+      )
+    } else if (instr instanceof CallInstruction) {
+      const func = this.heap.get_value(this.context.peekOSIdx(instr.args))
+      if (!(func instanceof FuncNode))
+        throw Error('Stack does not contain closure')
+      const cur_env = this.context.E().addr
+      this.context.pushRTS(
+        CallRefNode.create(this.context.PC(), this.heap).addr,
+      )
+      this.context.pushRTS(cur_env)
+      this.context.set_PC(func.PC())
     } else if (instr instanceof ReturnInstruction) {
-      // pass
+      let val = null
+      do {
+        val = this.heap.get_value(this.context.popRTS())
+      } while (!(val instanceof CallRefNode))
+      this.context.set_PC(val.PC())
     } else {
       throw Error('Invalid Instruction')
     }

--- a/src/virtual-machine/heap/index.ts
+++ b/src/virtual-machine/heap/index.ts
@@ -1,5 +1,6 @@
 import { ContextNode } from './types/context'
 import { EnvironmentNode, FrameNode } from './types/environment'
+import { CallRefNode, FuncNode } from './types/func'
 import {
   BoolNode,
   FloatNode,
@@ -23,6 +24,8 @@ export enum TAG {
   STRING_LIST = 8,
   STACK = 9,
   LIST = 10,
+  FUNC = 11,
+  CALLREF = 12,
 }
 
 export const word_size = 4
@@ -83,6 +86,10 @@ export class Heap {
         return new ListNode(this, addr)
       case TAG.STACK:
         return new StackNode(this, addr)
+      case TAG.FUNC:
+        return new FuncNode(this, addr)
+      case TAG.CALLREF:
+        return new CallRefNode(this, addr)
       default:
         throw Error('Unknown Data Type')
     }
@@ -254,6 +261,7 @@ export class Heap {
   }
 
   mark(addr: number) {
+    if (addr === -1) return
     if (this.is_marked(addr)) return
     this.set_mark(addr, true)
     const children = this.get_value(addr).get_children()

--- a/src/virtual-machine/heap/types/context.ts
+++ b/src/virtual-machine/heap/types/context.ts
@@ -60,6 +60,15 @@ export class ContextNode extends BaseNode {
     return this.OS().peek()
   }
 
+  /**
+   * @param val 0-indexed from the back
+   * @returns
+   */
+  peekOSIdx(val: number) {
+    const sz = this.OS().sz()
+    return this.OS().get_idx(sz - val - 1)
+  }
+
   popOS() {
     return this.OS().pop()
   }
@@ -82,7 +91,9 @@ export class ContextNode extends BaseNode {
     const old_E = this.RTS().pop()
     if (!old_E) throw Error('RTS Stack Empty')
     this.heap.memory.set_word(old_E, this.addr + 3)
+    return old_E
   }
+
   printRTS() {
     console.log('RTS:')
     for (let i = 0; i < this.RTS().sz(); i++) {
@@ -95,7 +106,8 @@ export class ContextNode extends BaseNode {
 
   override get_children(): number[] {
     const children = [this.RTS().addr, this.OS().addr]
-    if (this.E().addr !== -1) children.push(this.E().addr)
+    const E_addr = this.heap.memory.get_word(this.addr + 3)
+    if (E_addr !== -1) children.push(E_addr)
     return children
   }
 }

--- a/src/virtual-machine/heap/types/func.ts
+++ b/src/virtual-machine/heap/types/func.ts
@@ -1,0 +1,43 @@
+import { Heap, TAG } from '..'
+
+import { BaseNode } from './base'
+
+export class FuncNode extends BaseNode {
+  static create(PC: number, env: number, heap: Heap) {
+    const addr = heap.allocate(3)
+
+    heap.set_tag(addr, TAG.FUNC)
+    heap.memory.set_word(PC, addr + 1)
+    heap.memory.set_word(env, addr + 2)
+    return new FuncNode(heap, addr)
+  }
+
+  static default(heap: Heap) {
+    return FuncNode.create(-1, -1, heap)
+  }
+
+  PC() {
+    return this.heap.memory.get_word(this.addr + 1)
+  }
+
+  E() {
+    return this.heap.memory.get_word(this.addr + 2)
+  }
+
+  override get_children(): number[] {
+    return [this.E()]
+  }
+}
+
+export class CallRefNode extends BaseNode {
+  static create(PC: number, heap: Heap) {
+    const addr = heap.allocate(2)
+
+    heap.set_tag(addr, TAG.CALLREF)
+    heap.memory.set_word(PC, addr + 1)
+    return new CallRefNode(heap, addr)
+  }
+  PC() {
+    return this.heap.memory.get_word(this.addr + 1)
+  }
+}

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -1,3 +1,5 @@
+import { CallInstruction } from 'src/virtual-machine/compiler/instructions/funcs'
+
 import { Compiler } from '../../compiler'
 import { FunctionType, NoType, Type, TypeUtility } from '../../compiler/typing'
 
@@ -104,6 +106,7 @@ export class CallToken extends PrimaryExpressionModifierToken {
     }
 
     const argumentTypes = this.expressions.map((e) => e.compile(compiler))
+    compiler.instructions.push(new CallInstruction(this.expressions.length))
 
     if (argumentTypes.length < operandType.parameters.length) {
       throw Error(

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -1,6 +1,5 @@
-import { CallInstruction } from 'src/virtual-machine/compiler/instructions/funcs'
-
 import { Compiler } from '../../compiler'
+import { CallInstruction } from '../../compiler/instructions/funcs'
 import { FunctionType, NoType, Type, TypeUtility } from '../../compiler/typing'
 
 import { Token } from './base'

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -132,6 +132,6 @@ export class CallToken extends PrimaryExpressionModifierToken {
 
     if (operandType.results.length === 0) return new NoType()
     //! TODO: How to handle returning multiple values?
-    return new NoType()
+    return operandType.results[0].type
   }
 }

--- a/src/virtual-machine/parser/tokens/literals.ts
+++ b/src/virtual-machine/parser/tokens/literals.ts
@@ -1,9 +1,18 @@
 import { Compiler } from '../../compiler'
-import { DataType, LoadConstantInstruction } from '../../compiler/instructions'
+import {
+  DataType,
+  FuncBlockInstruction,
+  JumpInstruction,
+  LoadConstantInstruction,
+  LoadFuncInstruction,
+  PopInstruction,
+  ReturnInstruction,
+} from '../../compiler/instructions'
 import { Float64Type, Int64Type, StringType, Type } from '../../compiler/typing'
 
 import { Token } from './base'
 import { BlockToken } from './block'
+import { isExpressionToken } from './expressions'
 import { FunctionTypeToken } from './type'
 
 export abstract class LiteralToken extends Token {
@@ -86,7 +95,38 @@ export class FunctionLiteralToken extends Token {
   }
 
   override compile(compiler: Compiler): Type {
-    //! TODO: Implement compiling the function body.
+    compiler.context.push_env()
+    const jump_instr = new JumpInstruction()
+    compiler.instructions.push(jump_instr)
+    const func_start = compiler.instructions.length
+    const block_instr = new FuncBlockInstruction(
+      this.signature.parameters.length,
+    )
+    compiler.instructions.push(block_instr)
+    compiler.type_environment = compiler.type_environment.extend()
+
+    let cnt = 0
+    for (const param of this.signature.parameters) {
+      const name = param.identifier || (cnt++).toString()
+      compiler.context.env.declare_var(name)
+      compiler.type_environment.addType(name, param.type.compile(compiler))
+    }
+
+    for (const sub_token of this.body.statements) {
+      sub_token.compile(compiler)
+      if (isExpressionToken(sub_token))
+        compiler.instructions.push(new PopInstruction())
+    }
+    const vars = compiler.context.env.get_frame()
+    block_instr.set_frame(
+      vars.map((name) => compiler.type_environment.get(name)),
+    )
+    compiler.type_environment = compiler.type_environment.pop()
+    compiler.context.pop_env()
+
+    compiler.instructions.push(new ReturnInstruction())
+    jump_instr.set_addr(compiler.instructions.length)
+    compiler.instructions.push(new LoadFuncInstruction(func_start))
     return this.signature.compile(compiler)
   }
 }

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -35,3 +35,16 @@ describe('Function Type Checking', () => {
     ).toEqual('Cannot use string as int64 in argument to function call')
   })
 })
+
+describe('Function Execution tests', () => {
+  test('Function Literals', () => {
+    expect(
+      mainRunner(
+        'f := func(x int, y int) int{\
+        return x + y\
+      }\
+      return 1 + f(1, 2)',
+      ).output,
+    ).toEqual('4')
+  })
+})


### PR DESCRIPTION
# Feature
Compliation and Execution of literal functions

### Note
- Unnamed variables are currently named "0", "1", ... for ease. I do not foresee any potential issues with this fix
- Note that the `RTS` will now contain both `EnvironmentNode` and `CallRefNode` and it is the developer's responsibility to ensure that `E()` is always referencing a `EnvironmentNode` otherwise you will get an error
- The main function is hardcoded to act as a function (return will terminate the program) by pushing a `CallRefNode` on the `RTS` at the start of the program