### PR TITLE
Feat/concurrency parsing

### DIFF
--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -185,6 +185,41 @@ export class FunctionType extends Type {
   }
 }
 
+export class ChannelType extends Type {
+  constructor(
+    public element: Type,
+    public readable: boolean,
+    public writable: boolean,
+  ) {
+    super()
+  }
+
+  override isPrimitive(): boolean {
+    return false
+  }
+
+  override toString(): string {
+    if (this.readable && this.writable) {
+      return `chan ${this.element}`
+    } else if (this.readable) {
+      return `<-chan ${this.element}`
+    } else {
+      return `chan<- ${this.element}`
+    }
+  }
+
+  //! TODO: Read up on how Golang handles type checking for channels,
+  //! such that we can use a `chan` for something that takes `chan<-`.
+  override equals(t: Type): boolean {
+    return (
+      t instanceof ChannelType &&
+      this.readable === t.readable &&
+      this.writable === t.writable &&
+      this.element.equals(t.element)
+    )
+  }
+}
+
 export const TypeUtility = {
   // Similar to Array.toString(), but adds a space after each comma.
   arrayToString(types: Type[] | null) {

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -38,6 +38,10 @@
     SwitchStatementToken,
     FunctionLiteralToken,
     GoStatementToken,
+    SendStatementToken,
+    ReceiveStatementToken,
+    CommunicationClauseToken,
+    SelectStatementToken,
   } from './tokens'
 
   // Checks whether an identifier is valid (not a reserved keyword).
@@ -402,7 +406,8 @@ Label       = identifier
 ExpressionStmt = Expression
 
 //* Send Statements
-SendStmt = Channel _ "<-" _ Expression
+SendStmt = channel:Channel _ "<-" _ value:Expression { return new SendStatementToken(channel, value) }
+// For simplicity, we only allow channels to be identifiers instead of Expression
 Channel  = Expression
 
 //* IncDec Statements
@@ -455,11 +460,15 @@ GoStmt = "go" _ expr:PrimaryExpr &{ return GoStatementToken.isValidGoroutine(exp
          { return new GoStatementToken(expr) }
 
 //* Select Statements
-SelectStmt = "select" _ "{" _ (_ CommClause _)? _ "}"
-CommClause = CommCase _ ":" _ StatementList
-CommCase   = "case" _ (SendStmt / RecvStmt)? / "default"
-RecvStmt   = (ExpressionList _ "=" / IdentifierList _ ":=")? RecvExpr
-RecvExpr   = Expression
+SelectStmt = "select" _ "{" _ clauses:(_ @CommClause _)* _ "}" { return new SelectStatementToken(clauses ?? []) }
+CommClause = predicate:CommCase _ ":" _ body:StatementList
+             { return new CommunicationClauseToken(predicate, body) }
+CommCase   = "case" _ @(RecvStmt / SendStmt) / @"default"
+// For simplicity, we disallow an ExpressionList with assignment here.
+RecvStmt   = identifiers:(@IdentifierList _ ":=")? _ channel:RecvExpr
+             &{ return ReceiveStatementToken.isReceiveStatement(identifiers) }
+             { return new ReceiveStatementToken(identifiers, channel) }
+RecvExpr   = expr:Expression &{ return expr instanceof UnaryOperator && expr.name === 'receive' } { return expr }
 
 //* Return Statements
 ReturnStmt = "return" _ returns:ExpressionList?

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -37,6 +37,7 @@
     SwitchCaseToken,
     SwitchStatementToken,
     FunctionLiteralToken,
+    GoStatementToken,
   } from './tokens'
 
   // Checks whether an identifier is valid (not a reserved keyword).
@@ -384,8 +385,7 @@ Conversion = Type _ "(" _ Expression _ ")" _ ","? _ ")"
 //* Statements
 //! TODO (P5): LabeledStmt, GotoStmt are not tokenized as they're probably not so important.
 //!            Note that labels do not work for now.
-//! TODO (P4): SwitchStmt should be tokenized.
-//! TODO (P3): GoStmt, SelectStmt should be tokenized when we add concurrency.
+//! TODO (P3): SelectStmt should be tokenized when we add concurrency.
 Statement  = Declaration / LabeledStmt / SimpleStmt /
 	           GoStmt / ReturnStmt / BreakStmt / ContinueStmt / GotoStmt /
              FallthroughStmt / Block / IfStmt / SwitchStmt / SelectStmt / ForStmt /
@@ -451,7 +451,8 @@ PostStmt  = SimpleStmt
 RangeClause = (ExpressionList _ "=" / IdentifierList _ ":=")? _ "range" _ Expression
 
 //* Go Statements
-GoStmt = "go" _ Expression
+GoStmt = "go" _ expr:PrimaryExpr &{ return GoStatementToken.isValidGoroutine(expr) }
+         { return new GoStatementToken(expr) }
 
 //* Select Statements
 SelectStmt = "select" _ "{" _ (_ CommClause _)? _ "}"

--- a/src/virtual-machine/parser/tokens/statement.ts
+++ b/src/virtual-machine/parser/tokens/statement.ts
@@ -18,7 +18,11 @@ import { NoType, Type } from '../../compiler/typing'
 import { Token } from './base'
 import { BlockToken } from './block'
 import { DeclarationToken, ShortVariableDeclarationToken } from './declaration'
-import { ExpressionToken } from './expressions'
+import {
+  CallToken,
+  ExpressionToken,
+  PrimaryExpressionToken,
+} from './expressions'
 
 //! TODO (P1): Add other types of statements and expressions
 export type StatementToken =
@@ -295,6 +299,26 @@ export class DeferStatementToken extends Token {
 
   override compile(_compiler: Compiler): Type {
     // TODO: Implement
+    return new NoType()
+  }
+}
+
+export class GoStatementToken extends Token {
+  constructor(public call: PrimaryExpressionToken) {
+    super('go')
+  }
+
+  /** Used in the parser to only parse function calls */
+  static isValidGoroutine(expression: PrimaryExpressionToken) {
+    return (
+      expression.rest &&
+      expression.rest.length > 0 &&
+      expression.rest[expression.rest.length - 1] instanceof CallToken
+    )
+  }
+
+  override compile(_compiler: Compiler): Type {
+    //! TODO: Implement.
     return new NoType()
   }
 }

--- a/src/virtual-machine/parser/tokens/statement.ts
+++ b/src/virtual-machine/parser/tokens/statement.ts
@@ -23,6 +23,7 @@ import {
   ExpressionToken,
   PrimaryExpressionToken,
 } from './expressions'
+import { IdentifierToken } from './identifier'
 
 //! TODO (P1): Add other types of statements and expressions
 export type StatementToken =
@@ -35,6 +36,7 @@ export type SimpleStatementToken =
   | AssignmentStatementToken
   | ShortVariableDeclarationToken
   | ExpressionToken
+  | SendStatementToken
 
 export class AssignmentStatementToken extends Token {
   constructor(
@@ -315,6 +317,65 @@ export class GoStatementToken extends Token {
       expression.rest.length > 0 &&
       expression.rest[expression.rest.length - 1] instanceof CallToken
     )
+  }
+
+  override compile(_compiler: Compiler): Type {
+    //! TODO: Implement.
+    return new NoType()
+  }
+}
+
+/** Sends a `value` into `channel`. */
+export class SendStatementToken extends Token {
+  constructor(public channel: IdentifierToken, public value: ExpressionToken) {
+    super('send')
+  }
+
+  override compile(_compiler: Compiler): Type {
+    //! TODO: Implement.
+    return new NoType()
+  }
+}
+
+/** Receive and assign the results to one or two variables. Note that RecvStmt is NOT a SimpleStmt. */
+export class ReceiveStatementToken extends Token {
+  constructor(
+    public identifiers: IdentifierToken[] | null,
+    public channel: ExpressionToken,
+  ) {
+    super('receive')
+  }
+
+  /** Used in the parser to only parse valid receive statements. */
+  static isReceiveStatement(identifiers: IdentifierToken[] | null) {
+    return (
+      identifiers === null ||
+      (identifiers.length > 0 && identifiers.length <= 2)
+    )
+  }
+
+  override compile(_compiler: Compiler): Type {
+    //! TODO: Implement.
+    return new NoType()
+  }
+}
+
+export class SelectStatementToken extends Token {
+  constructor(public clauses: CommunicationClauseToken[]) {
+    super('select')
+  }
+
+  override compile(_compiler: Compiler): Type {
+    //! TODO: Implement.
+    return new NoType()
+  }
+}
+export class CommunicationClauseToken extends Token {
+  constructor(
+    public predicate: 'default' | SendStatementToken | ReceiveStatementToken,
+    public body: StatementToken[],
+  ) {
+    super('communication_clause')
   }
 
   override compile(_compiler: Compiler): Type {

--- a/src/virtual-machine/parser/tokens/type.ts
+++ b/src/virtual-machine/parser/tokens/type.ts
@@ -1,5 +1,6 @@
 import { Compiler } from '../../compiler'
 import {
+  ArrayType,
   BoolType,
   ChannelType,
   Float64Type,
@@ -7,6 +8,7 @@ import {
   Int64Type,
   NoType,
   ParameterType,
+  SliceType,
   StringType,
   Type,
   Uint64Type,
@@ -78,9 +80,8 @@ export class ArrayTypeToken extends TypeToken {
     super()
   }
 
-  override compile(_compiler: Compiler): Type {
-    //! TODO: Implement.
-    return new NoType()
+  override compile(compiler: Compiler): Type {
+    return new ArrayType(this.element.compile(compiler), this.length.getValue())
   }
 }
 
@@ -89,9 +90,8 @@ export class SliceTypeToken extends TypeToken {
     super()
   }
 
-  override compile(_compiler: Compiler): Type {
-    //! TODO: Implement.
-    return new NoType()
+  override compile(compiler: Compiler): Type {
+    return new SliceType(this.element.compile(compiler))
   }
 }
 

--- a/src/virtual-machine/parser/tokens/type.ts
+++ b/src/virtual-machine/parser/tokens/type.ts
@@ -1,6 +1,7 @@
 import { Compiler } from '../../compiler'
 import {
   BoolType,
+  ChannelType,
   Float64Type,
   FunctionType,
   Int64Type,
@@ -139,8 +140,11 @@ export class ChannelTypeToken extends TypeToken {
     super()
   }
 
-  override compile(_compiler: Compiler): Type {
-    //! TODO: Implement.
-    return new NoType()
+  override compile(compiler: Compiler): Type {
+    return new ChannelType(
+      this.element.compile(compiler),
+      this.readable,
+      this.writable,
+    )
   }
 }

--- a/tests/channel.test.ts
+++ b/tests/channel.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest'
+
+import { mainRunner } from './utility'
+
+describe('Channel Type Checking', () => {
+  test('Assign int to channel should fail', () => {
+    expect(mainRunner('var a <-chan int = 1').errorMessage).toEqual(
+      'Cannot use int64 as <-chan int64 in variable declaration',
+    )
+  })
+})


### PR DESCRIPTION
This PR adds parsing for channels, send / receive statements and select statements, as well as compiling array and slice types.

Type checking for concurrency structures is a WIP, we need to add some way of determining whether a variable of type `A` can be used as type `B`, such as passing a `chan` into a parameter of type `chan<-`.