### PR TITLE
Feat/builtins

### DIFF
--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -3,6 +3,10 @@ export abstract class Type {
   abstract toString(): string
 
   abstract equals(t: Type): boolean
+  /** Returns true if `t` can be assigned to this type. */
+  assignableBy(t: Type): boolean {
+    return this.equals(t)
+  }
 }
 
 /** This type represents things that don't have an associated type, like statements. */
@@ -208,14 +212,22 @@ export class ChannelType extends Type {
     }
   }
 
-  //! TODO: Read up on how Golang handles type checking for channels,
-  //! such that we can use a `chan` for something that takes `chan<-`.
   override equals(t: Type): boolean {
     return (
       t instanceof ChannelType &&
       this.readable === t.readable &&
       this.writable === t.writable &&
       this.element.equals(t.element)
+    )
+  }
+
+  override assignableBy(t: Type): boolean {
+    return (
+      this.equals(t) ||
+      (this.readable &&
+        this.writable &&
+        t instanceof ChannelType &&
+        this.element.equals(t.element))
     )
   }
 }

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -42,6 +42,7 @@
     ReceiveStatementToken,
     CommunicationClauseToken,
     SelectStatementToken,
+    BuiltinCallToken,
   } from './tokens'
 
   // Checks whether an identifier is valid (not a reserved keyword).
@@ -217,7 +218,7 @@ KeyType = Type
 //* Channel Types
 ChannelType = "chan" _ "<-" _ element:ElementType { return new ChannelTypeToken(element, false, true) }
               / "<-" _ "chan" _ element:ElementType { return new ChannelTypeToken(element, true, false) }
-              / "chan" _ ElementType { return new ChannelTypeToken(element, true, true) }
+              / "chan" _ element:ElementType { return new ChannelTypeToken(element, true, true) }
 
 
 
@@ -318,7 +319,7 @@ FunctionLit = "func" _ signature:Signature _ body:FunctionBody { return new Func
 
 //* Primary Expressions
 //! TODO (P5): MethodExpr and Conversion are not supported.
-PrimaryExpr     = operand:Operand _ rest:PrimaryExprModifier* { return new PrimaryExpressionToken(operand, rest) }
+PrimaryExpr     = operand:(@BuiltinCall / @Operand) _ rest:PrimaryExprModifier* { return new PrimaryExpressionToken(operand, rest) }
 //! TODO (P2): Tokenize PrimaryExprModifier.
 // This PrimaryExprTerm is added to fix left recursion.
 PrimaryExprModifier = Selector / Index / Slice / TypeAssertion / Arguments
@@ -328,8 +329,15 @@ Index         = "[" _ expr:Expression (_ ",")? _ "]" { return new IndexToken(exp
 Slice         = "[" _ from:Expression? _ ":" _ to:Expression? _ "]" { return new SliceToken(from, to) }
 TypeAssertion = "." _ "(" _ Type _ ")"
 // Note: Variadic arguments are not supported.
-//! TODO (P5): Find out why Golang's spec say that Arguments can contain Type, and is it ok to ignore it?
+// Note: Golang specs allow a Type to be the first argument, but it is only used for certain builtin functions.
+// We split BuiltinCall out to a separate token to allow parsing types as first argument.
 Arguments     = "(" _ exprs:ExpressionList? _ ","? _ ")" { return new CallToken(exprs) }
+
+//* Builtin Call (This is not in Golang specifications)
+BuiltinCall   = name:$[a-z]+ _ "(" _ type:Type _ args:("," _ @ExpressionList)? _ ")"
+                &{ return BuiltinCallToken.namesThatTakeType.includes(name) } { return new BuiltinCallToken(name, type, args ?? []) }
+              / name:$[a-z]+ _ "(" _ args:ExpressionList? _ ")"
+                &{ return !BuiltinCallToken.namesThatTakeType.includes(name) } { return new BuiltinCallToken(name, null, args ?? []) }
 
 //* Method Expressions
 MethodExpr   = ReceiverType "." MethodName

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -335,9 +335,11 @@ Arguments     = "(" _ exprs:ExpressionList? _ ","? _ ")" { return new CallToken(
 
 //* Builtin Call (This is not in Golang specifications)
 BuiltinCall   = name:$[a-z]+ _ "(" _ type:Type _ args:("," _ @ExpressionList)? _ ")"
-                &{ return BuiltinCallToken.namesThatTakeType.includes(name) } { return new BuiltinCallToken(name, type, args ?? []) }
+                &{ return BuiltinCallToken.validNames.includes(name) && BuiltinCallToken.namesThatTakeType.includes(name) }
+                { return new BuiltinCallToken(name, type, args ?? []) }
               / name:$[a-z]+ _ "(" _ args:ExpressionList? _ ")"
-                &{ return !BuiltinCallToken.namesThatTakeType.includes(name) } { return new BuiltinCallToken(name, null, args ?? []) }
+                &{ return BuiltinCallToken.validNames.includes(name) && !BuiltinCallToken.namesThatTakeType.includes(name) }
+                { return new BuiltinCallToken(name, null, args ?? []) }
 
 //* Method Expressions
 MethodExpr   = ReceiverType "." MethodName

--- a/src/virtual-machine/parser/tokens/declaration.ts
+++ b/src/virtual-machine/parser/tokens/declaration.ts
@@ -102,7 +102,7 @@ export class VariableDeclarationToken extends DeclarationToken {
         const expression = expressions[i]
         const [frame_idx, var_idx] = compiler.context.env.find_var(identifier)
         const expressionType = expression.compile(compiler)
-        if (expectedType && !expectedType.equals(expressionType)) {
+        if (expectedType && !expectedType.assignableBy(expressionType)) {
           throw Error(
             `Cannot use ${expressionType} as ${expectedType} in variable declaration`,
           )
@@ -149,7 +149,7 @@ export class ConstantDeclarationToken extends DeclarationToken {
       const expr = expressions[i]
       const [frame_idx, var_idx] = compiler.context.env.declare_var(var_name)
       const expressionType = expr.compile(compiler)
-      if (expectedType && !expressionType.equals(expectedType)) {
+      if (expectedType && !expressionType.assignableBy(expectedType)) {
         throw Error(
           `Cannot use ${expressionType} as ${expectedType} in constant declaration`,
         )

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -12,6 +12,7 @@ export type ExpressionToken =
   | UnaryOperator
   | BinaryOperator
   | PrimaryExpressionToken
+  | BuiltinCallToken
 
 export function isExpressionToken(obj: any): obj is ExpressionToken {
   return (
@@ -132,5 +133,58 @@ export class CallToken extends PrimaryExpressionModifierToken {
     if (operandType.results.length === 0) return new NoType()
     //! TODO: How to handle returning multiple values?
     return operandType.results[0].type
+  }
+}
+
+type BuiltinFunctionName = (typeof BuiltinCallToken.validNames)[number]
+// The following builtin functions are omitted: new, panic, recover.
+// This does not extend from PrimaryExpression because its parsing is completely separate:
+// Certain builtin functions take in a type as the first argument (as opposed to a value).
+export class BuiltinCallToken extends Token {
+  static validNames = [
+    'append',
+    'clear',
+    'close',
+    'delete',
+    'len',
+    'cap',
+    'make',
+    'min',
+    'max',
+  ] as const
+
+  static namesThatTakeType = ['make'] as const
+
+  constructor(
+    public name: BuiltinFunctionName,
+    /** The first argument if it is a type. */
+    public firstTypeArg: Type | null,
+    public args: ExpressionToken[],
+  ) {
+    super('builtin')
+  }
+
+  override compile(_compiler: Compiler): Type {
+    switch (this.name) {
+      //! TODO: Implement.
+      case 'append':
+        return new NoType()
+      case 'clear':
+        return new NoType()
+      case 'close':
+        return new NoType()
+      case 'delete':
+        return new NoType()
+      case 'len':
+        return new NoType()
+      case 'cap':
+        return new NoType()
+      case 'make':
+        return new NoType()
+      case 'min':
+        return new NoType()
+      case 'max':
+        return new NoType()
+    }
   }
 }

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -1,11 +1,19 @@
 import { Compiler } from '../../compiler'
 import { CallInstruction } from '../../compiler/instructions/funcs'
-import { FunctionType, NoType, Type, TypeUtility } from '../../compiler/typing'
+import {
+  ChannelType,
+  FunctionType,
+  NoType,
+  SliceType,
+  Type,
+  TypeUtility,
+} from '../../compiler/typing'
 
 import { Token } from './base'
 import { IdentifierToken } from './identifier'
 import { LiteralToken } from './literals'
 import { BinaryOperator, UnaryOperator } from './operator'
+import { TypeToken } from './type'
 
 export type ExpressionToken =
   | LiteralToken
@@ -158,33 +166,24 @@ export class BuiltinCallToken extends Token {
   constructor(
     public name: BuiltinFunctionName,
     /** The first argument if it is a type. */
-    public firstTypeArg: Type | null,
+    public firstTypeArg: TypeToken | null,
     public args: ExpressionToken[],
   ) {
     super('builtin')
   }
 
-  override compile(_compiler: Compiler): Type {
-    switch (this.name) {
-      //! TODO: Implement.
-      case 'append':
-        return new NoType()
-      case 'clear':
-        return new NoType()
-      case 'close':
-        return new NoType()
-      case 'delete':
-        return new NoType()
-      case 'len':
-        return new NoType()
-      case 'cap':
-        return new NoType()
-      case 'make':
-        return new NoType()
-      case 'min':
-        return new NoType()
-      case 'max':
-        return new NoType()
+  override compile(compiler: Compiler): Type {
+    if (this.name === 'make') {
+      const typeArg = (this.firstTypeArg as TypeToken).compile(compiler)
+      if (!(typeArg instanceof SliceType || typeArg instanceof ChannelType)) {
+        throw new Error(
+          `Invalid argument: cannot make ${typeArg}; type must be slice, map, or channel`,
+        )
+      }
+      //! TODO: Construct based on the args.
+      return typeArg
+    } else {
+      throw new Error(`Builtin function ${this.name} is not yet implemented.`)
     }
   }
 }

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -132,7 +132,8 @@ export class CallToken extends PrimaryExpressionModifierToken {
     }
 
     for (let i = 0; i < argumentTypes.length; i++) {
-      if (argumentTypes[i].equals(operandType.parameters[i].type)) continue
+      if (argumentTypes[i].assignableBy(operandType.parameters[i].type))
+        continue
       throw Error(
         `Cannot use ${argumentTypes[i]} as ${operandType.parameters[i]} in argument to function call`,
       )

--- a/src/virtual-machine/parser/tokens/statement.ts
+++ b/src/virtual-machine/parser/tokens/statement.ts
@@ -79,7 +79,7 @@ export class AssignmentStatementToken extends Token {
         throw Error('Unimplemented')
       }
       const varType = left.compile(compiler)
-      if (!varType.equals(assignType)) {
+      if (!varType.assignableBy(assignType)) {
         throw Error(`Cannot use ${assignType} as ${varType} in assignment`)
       }
       compiler.instructions.push(new StoreInstruction())

--- a/tests/builtin.test.ts
+++ b/tests/builtin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest'
+
+import { mainRunner } from './utility'
+
+describe('Builtins Type Checking', () => {
+  test('Assignment of make with incompatible type should fail', () => {
+    expect(
+      mainRunner('var a chan int = make(chan string)').errorMessage,
+    ).toEqual('Cannot use chan string as chan int64 in variable declaration')
+  })
+})


### PR DESCRIPTION
This PR adds parsing for builtin functions, and partially type checks `make`. It also updates type checking assignment to use assignability instead of equality. More work can be done on builtin functions once we settle array and slice types.