### PR TITLE
fix: recursive functions

### DIFF
--- a/src/virtual-machine/parser/tokens/declaration.ts
+++ b/src/virtual-machine/parser/tokens/declaration.ts
@@ -26,8 +26,14 @@ export class FunctionDeclarationToken extends Token {
     const [frame_idx, var_idx] = compiler.context.env.declare_var(
       this.name.identifier,
     )
-    const functionType = this.func.compile(compiler)
-    compiler.type_environment.addType(this.name.identifier, functionType)
+    //! TODO (P5): There is a double compilation of func.signature, once here and
+    //! once in the func.compile() call. Not really an issue as compiling types has
+    //! no side effects, but would be nice to fix.
+    compiler.type_environment.addType(
+      this.name.identifier,
+      this.func.signature.compile(compiler),
+    )
+    this.func.compile(compiler)
     compiler.instructions.push(new LoadVariableInstruction(frame_idx, var_idx))
     compiler.instructions.push(new StoreInstruction())
     return new NoType()

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -113,4 +113,24 @@ describe('Function Execution tests', () => {
       ).output,
     ).toEqual('103')
   })
+
+  test('Recursive function', () => {
+    expect(
+      runCode(
+        `package main
+
+      func f(x int) int {
+        if x == 0 {
+          return 0
+        }
+        return f(x - 1) + 1
+      }
+      
+      func main() {
+        return f(10)
+      }`,
+        2048,
+      ).output,
+    ).toEqual('10')
+  })
 })


### PR DESCRIPTION
This PR fixes the bug where recursive functions fail type checking, as they were added into the type environment after compiling the body.

The following code (added to test) now works:

```golang
package main

func f(x int) int {
  if x == 0 {
    return 0
  }
  return f(x - 1) + 1
}

func main() {
  return f(10)
}
```