### PR TITLE
Feat/function type checking

### DIFF
--- a/src/virtual-machine/compiler/instructions/funcs.ts
+++ b/src/virtual-machine/compiler/instructions/funcs.ts
@@ -1,5 +1,6 @@
 import { Process } from '../../executor/process'
 import { CallRefNode, FuncNode } from '../../heap/types/func'
+import { IntegerNode } from '../../heap/types/primitives'
 
 import { Instruction } from './base'
 
@@ -59,5 +60,31 @@ export class ReturnInstruction extends Instruction {
       val = process.heap.get_value(process.context.popRTS())
     } while (!(val instanceof CallRefNode))
     process.context.set_PC(val.PC())
+  }
+}
+
+/**
+ * Takes the top of the OS to be the number of arguments.
+ * Then takes its arguments from the OS (in reverse order), and prints them out.
+ */
+export class PrintInstruction extends Instruction {
+  constructor() {
+    super('PRINT')
+  }
+
+  override execute(process: Process): void {
+    const numOfArgs = new IntegerNode(
+      process.heap,
+      process.context.popOS(),
+    ).get_value()
+    const argAddresses = []
+    for (let i = 0; i < numOfArgs; i++) {
+      argAddresses.push(process.context.popOS())
+    }
+    for (let i = numOfArgs - 1; i >= 0; i--) {
+      const string = process.heap.get_value(argAddresses[i]).toString()
+      process.print(string)
+      process.print(i > 0 ? ' ' : '\n')
+    }
   }
 }

--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -206,10 +206,7 @@ export class ParameterType extends Type {
 }
 
 export class FunctionType extends Type {
-  constructor(
-    public parameters: ParameterType[],
-    public results: ParameterType[],
-  ) {
+  constructor(public parameters: ParameterType[], public results: ReturnType) {
     super()
   }
 
@@ -219,23 +216,15 @@ export class FunctionType extends Type {
 
   toString(): string {
     const parametersString = TypeUtility.arrayToString(this.parameters)
-    const resultsString = TypeUtility.arrayToString(this.results)
-    if (this.results.length === 0) {
-      return `func(${parametersString})`
-    }
-    if (this.results.length === 1) {
-      return `func(${parametersString}) ${resultsString}`
-    }
-    return `func(${parametersString}) (${resultsString})`
+    return `func(${parametersString}) ${this.results}`
   }
 
   override equals(t: Type): boolean {
     return (
       t instanceof FunctionType &&
       this.parameters.length === t.parameters.length &&
-      this.results.length === t.results.length &&
       this.parameters.every((p, index) => p.equals(t.parameters[index])) &&
-      this.results.every((r, index) => r.equals(t.results[index]))
+      this.results.equals(t.results)
     )
   }
 
@@ -289,6 +278,37 @@ export class ChannelType extends Type {
   override defaultNodeCreator(): (heap: Heap) => number {
     //! TODO: Implement.
     throw new Error('Channels are not supported yet.')
+  }
+}
+
+export class ReturnType extends Type {
+  constructor(public types: Type[]) {
+    super()
+  }
+
+  override isPrimitive(): boolean {
+    return false
+  }
+
+  override toString(): string {
+    return `(${TypeUtility.arrayToString(this.types)})`
+  }
+
+  override equals(t: Type): boolean {
+    return (
+      t instanceof ReturnType &&
+      t.types.length === this.types.length &&
+      this.types.every((r, index) => r.equals(t.types[index]))
+    )
+  }
+
+  override defaultNodeCreator(): (_heap: Heap) => number {
+    // Return values are pushed onto the OS, and should not be allocated.
+    throw Error('Unreachable')
+  }
+
+  isVoid(): boolean {
+    return this.types.length === 0
   }
 }
 

--- a/src/virtual-machine/compiler/typing/type_environment.ts
+++ b/src/virtual-machine/compiler/typing/type_environment.ts
@@ -1,12 +1,14 @@
-import { Type } from '.'
+import { ReturnType, Type } from '.'
 
 export class TypeEnvironment {
   parent?: TypeEnvironment
   typings: Record<string, Type>
+  expectedReturn: ReturnType
 
   constructor(parent?: TypeEnvironment) {
     this.parent = parent
     this.typings = {}
+    this.expectedReturn = parent?.expectedReturn ?? new ReturnType([])
   }
 
   addType(name: string, type: Type) {
@@ -35,5 +37,9 @@ export class TypeEnvironment {
       throw Error(`Variable ${name} not found`)
     }
     return this.parent.get(name)
+  }
+
+  updateReturnType(newType: ReturnType) {
+    this.expectedReturn = newType
   }
 }

--- a/src/virtual-machine/executor/process.ts
+++ b/src/virtual-machine/executor/process.ts
@@ -2,16 +2,17 @@ import { DoneInstruction, Instruction } from '../compiler/instructions'
 import { Heap } from '../heap'
 import { ContextNode } from '../heap/types/context'
 import { EnvironmentNode, FrameNode } from '../heap/types/environment'
-import { PrimitiveNode } from '../heap/types/primitives'
 
 export class Process {
   instructions: Instruction[]
   heap: Heap
   context: ContextNode
+  stdout: string
   constructor(instrs: Instruction[], heapsize: number) {
     this.instructions = instrs
     this.heap = new Heap(heapsize)
     this.context = new ContextNode(this.heap, this.heap.contexts.get_idx(0))
+    this.stdout = ''
     const base_frame = FrameNode.create(0, this.heap)
     const base_env = EnvironmentNode.create([base_frame.addr], false, this.heap)
     this.context.set_E(base_env.addr)
@@ -28,14 +29,15 @@ export class Process {
       runtime_count += 1
       if (runtime_count > 10 ** 5) throw Error('Time Limit Exceeded!')
     }
-    const returnVal = this.context.peekOS()
 
-    return returnVal
-      ? (this.heap.get_value(returnVal) as PrimitiveNode).get_value()
-      : undefined
+    return this.stdout
   }
 
   execute_microcode(instr: Instruction) {
     instr.execute(this)
+  }
+
+  print(string: string) {
+    this.stdout += string
   }
 }

--- a/src/virtual-machine/heap/types/primitives.ts
+++ b/src/virtual-machine/heap/types/primitives.ts
@@ -14,6 +14,10 @@ export abstract class PrimitiveNode extends BaseNode {
   abstract apply_binop(operand: PrimitiveNode, operator: string): PrimitiveNode
   abstract apply_unary(operator: string): PrimitiveNode
   abstract get_value(): number | boolean | string
+
+  override toString(): string {
+    return this.get_value().toString()
+  }
 }
 
 export class IntegerNode extends PrimitiveNode {
@@ -46,6 +50,7 @@ export class IntegerNode extends PrimitiveNode {
     }
     throw Error('Invalid Operation')
   }
+
   override apply_unary(operator: string): PrimitiveNode {
     if (NumUnaryOp[operator]) {
       return IntegerNode.create(

--- a/src/virtual-machine/index.ts
+++ b/src/virtual-machine/index.ts
@@ -11,7 +11,6 @@ interface ProgramData {
   output?: string
   instructions: InstructionData[]
   errorMessage?: string
-  returnVal: string
 }
 
 const runCode = (source_code: string, heapsize: number): ProgramData => {
@@ -24,16 +23,14 @@ const runCode = (source_code: string, heapsize: number): ProgramData => {
     const result = execute_instructions(instructions, heapsize)
     // console.log(result)
     return {
-      returnVal: 'test',
       instructions: [],
-      output: result === undefined ? 'undefined' : JSON.stringify(result),
+      output: result,
     }
   } catch (err) {
     console.warn(err)
     if (err instanceof Error) errorMessage = err.message
   }
   return {
-    returnVal: 'test',
     instructions: [],
     output: 'An Error Occurred!',
     errorMessage: errorMessage,

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -336,10 +336,10 @@ TypeAssertion = "." _ "(" _ Type _ ")"
 Arguments     = "(" _ exprs:ExpressionList? _ ","? _ ")" { return new CallToken(exprs) }
 
 //* Builtin Call (This is not in Golang specifications)
-BuiltinCall   = name:$[a-z]+ _ "(" _ type:Type _ args:("," _ @ExpressionList)? _ ")"
+BuiltinCall   = name:$[a-zA-Z]+ _ "(" _ type:Type _ args:("," _ @ExpressionList)? _ ")"
                 &{ return BuiltinCallToken.validNames.includes(name) && BuiltinCallToken.namesThatTakeType.includes(name) }
                 { return new BuiltinCallToken(name, type, args ?? []) }
-              / name:$[a-z]+ _ "(" _ args:ExpressionList? _ ")"
+              / name:$[a-zA-Z]+ _ "(" _ args:ExpressionList? _ ")"
                 &{ return BuiltinCallToken.validNames.includes(name) && !BuiltinCallToken.namesThatTakeType.includes(name) }
                 { return new BuiltinCallToken(name, null, args ?? []) }
 

--- a/src/virtual-machine/parser/tokens/block.ts
+++ b/src/virtual-machine/parser/tokens/block.ts
@@ -2,12 +2,10 @@ import { Compiler } from '../../compiler'
 import {
   BlockInstruction,
   ExitBlockInstruction,
-  PopInstruction,
 } from '../../compiler/instructions'
 import { NoType, ReturnType, Type } from '../../compiler/typing'
 
 import { Token } from './base'
-import { isExpressionToken } from './expressions'
 import { StatementToken } from './statement'
 
 export class BlockToken extends Token {

--- a/src/virtual-machine/parser/tokens/block.ts
+++ b/src/virtual-machine/parser/tokens/block.ts
@@ -4,7 +4,7 @@ import {
   ExitBlockInstruction,
   PopInstruction,
 } from '../../compiler/instructions'
-import { NoType, Type } from '../../compiler/typing'
+import { NoType, ReturnType, Type } from '../../compiler/typing'
 
 import { Token } from './base'
 import { isExpressionToken } from './expressions'
@@ -20,11 +20,15 @@ export class BlockToken extends Token {
     const block_instr = new BlockInstruction()
     compiler.instructions.push(block_instr)
     compiler.type_environment = compiler.type_environment.extend()
+    let hasReturn = false
     for (const sub_token of this.statements) {
-      sub_token.compile(compiler)
-      if (isExpressionToken(sub_token))
-        compiler.instructions.push(new PopInstruction())
+      const statementType = sub_token.compile(compiler)
+      hasReturn ||= statementType instanceof ReturnType
     }
+    const blockType = hasReturn
+      ? compiler.type_environment.expectedReturn
+      : new NoType()
+
     const vars = compiler.context.env.get_frame()
     block_instr.set_frame(
       vars.map((name) => compiler.type_environment.get(name)),
@@ -34,6 +38,6 @@ export class BlockToken extends Token {
 
     compiler.instructions.push(new ExitBlockInstruction())
 
-    return new NoType()
+    return blockType
   }
 }

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -159,6 +159,13 @@ export class CallToken extends PrimaryExpressionModifierToken {
       )
     }
 
+    if (operandType.results.isVoid()) {
+      return new NoType()
+    }
+    if (operandType.results.types.length === 1) {
+      // A return type with a single value can be unwrapped.
+      return operandType.results.types[0]
+    }
     return operandType.results
   }
 }

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -1,6 +1,12 @@
 import { Compiler } from '../../compiler'
-import { LoadArrayElementInstruction } from '../../compiler/instructions'
-import { CallInstruction } from '../../compiler/instructions/funcs'
+import {
+  LoadArrayElementInstruction,
+  LoadConstantInstruction,
+} from '../../compiler/instructions'
+import {
+  CallInstruction,
+  PrintInstruction,
+} from '../../compiler/instructions/funcs'
 import {
   ArrayType,
   ChannelType,
@@ -172,6 +178,7 @@ export class BuiltinCallToken extends Token {
     'make',
     'min',
     'max',
+    'Println',
   ] as const
 
   static namesThatTakeType = ['make'] as const
@@ -195,6 +202,14 @@ export class BuiltinCallToken extends Token {
       }
       //! TODO: Construct based on the args.
       return typeArg
+    } else if (this.name === 'Println') {
+      //! TODO: This should be fmt.Println.
+      for (const arg of this.args) arg.compile(compiler)
+      compiler.instructions.push(
+        new LoadConstantInstruction(this.args.length, new Int64Type()),
+      )
+      compiler.instructions.push(new PrintInstruction())
+      return new NoType()
     } else {
       throw new Error(`Builtin function ${this.name} is not yet implemented.`)
     }

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -121,7 +121,6 @@ export class CallToken extends PrimaryExpressionModifierToken {
   }
 
   override compile(compiler: Compiler, operandType: Type): Type {
-    //! TODO: Implement the actual calling of the function.
     if (!(operandType instanceof FunctionType)) {
       throw Error(
         `Invalid operation: cannot call non-function (of type ${operandType})`,
@@ -154,9 +153,7 @@ export class CallToken extends PrimaryExpressionModifierToken {
       )
     }
 
-    if (operandType.results.length === 0) return new NoType()
-    //! TODO: How to handle returning multiple values?
-    return operandType.results[0].type
+    return operandType.results
   }
 }
 

--- a/src/virtual-machine/parser/tokens/literals.ts
+++ b/src/virtual-machine/parser/tokens/literals.ts
@@ -6,7 +6,6 @@ import {
   LoadConstantInstruction,
   LoadDefaultInstruction,
   LoadFuncInstruction,
-  PopInstruction,
   ReturnInstruction,
 } from '../../compiler/instructions'
 import {
@@ -20,7 +19,7 @@ import {
 
 import { Token } from './base'
 import { BlockToken } from './block'
-import { ExpressionToken, isExpressionToken } from './expressions'
+import { ExpressionToken } from './expressions'
 import { ArrayTypeToken, FunctionTypeToken } from './type'
 
 export abstract class LiteralToken extends Token {

--- a/src/virtual-machine/parser/tokens/operator.ts
+++ b/src/virtual-machine/parser/tokens/operator.ts
@@ -3,7 +3,7 @@ import {
   BinaryInstruction,
   UnaryInstruction,
 } from '../../compiler/instructions'
-import { Type } from '../../compiler/typing'
+import { BoolType, Type } from '../../compiler/typing'
 
 import { Token } from './base'
 
@@ -58,6 +58,16 @@ export class BinaryOperator extends Operator {
       )
     }
     compiler.instructions.push(new BinaryInstruction(this.name))
-    return leftType
+    const logical_operators = [
+      'equal',
+      'not_equal',
+      'less',
+      'less_or_equal',
+      'greater',
+      'greater_or_equal',
+      'conditional_or',
+      'conditional_and',
+    ]
+    return logical_operators.includes(this.name) ? new BoolType() : leftType
   }
 }

--- a/src/virtual-machine/parser/tokens/type.ts
+++ b/src/virtual-machine/parser/tokens/type.ts
@@ -8,6 +8,7 @@ import {
   Int64Type,
   NoType,
   ParameterType,
+  ReturnType,
   SliceType,
   StringType,
   Type,
@@ -109,12 +110,12 @@ export class FunctionTypeToken extends TypeToken {
     this.results = results ?? []
   }
 
-  override compile(compiler: Compiler): Type {
+  override compile(compiler: Compiler): FunctionType {
     const parameterTypes = this.parameters.map(
       (p) => new ParameterType(p.identifier, p.type.compile(compiler)),
     )
-    const resultTypes = this.results.map(
-      (r) => new ParameterType(r.identifier, r.type.compile(compiler)),
+    const resultTypes = new ReturnType(
+      this.results.map((r) => r.type.compile(compiler)),
     )
     return new FunctionType(parameterTypes, resultTypes)
   }

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -19,7 +19,8 @@ describe('Array Type Checking', () => {
 
   test('Array indexing with non integer type should fail.', () => {
     expect(
-      mainRunner('var a [3]int = [3]int{1, 2, 3}; return a[1.2]').errorMessage,
+      mainRunner('var a [3]int = [3]int{1, 2, 3}; Println(a[1.2])')
+        .errorMessage,
     ).toEqual('Invalid argument: Index has type float64 but must be an integer')
   })
 })
@@ -27,21 +28,21 @@ describe('Array Type Checking', () => {
 describe('Array Execution', () => {
   test('Array indexing with valid index works.', () => {
     expect(
-      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n return a[2]')
+      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n Println(a[2])')
         .output,
-    ).toEqual('"c"')
+    ).toEqual('c\n')
   })
 
   test('Array indexing with negative index fails.', () => {
     expect(
-      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n return a[-1]')
+      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n Println(a[-1])')
         .errorMessage,
     ).toEqual('Index out of range [-1] with length 3')
   })
 
   test('Array indexing with out of range index fails.', () => {
     expect(
-      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n return a[3]')
+      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n Println(a[3])')
         .errorMessage,
     ).toEqual('Index out of range [3] with length 3')
   })
@@ -49,8 +50,8 @@ describe('Array Execution', () => {
   test('Nested arrays work.', () => {
     expect(
       mainRunner(
-        'a := [3][3]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}; return a[1][2]',
+        'a := [3][3]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}; Println(a[1][2])',
       ).output,
-    ).toEqual('6')
+    ).toEqual('6\n')
   })
 })

--- a/tests/control.test.ts
+++ b/tests/control.test.ts
@@ -13,9 +13,9 @@ describe('Variable Declaration Tests', () => {
         } else {\
           a += -i\
         }\
-        return a',
+        Println(a)',
       ).output,
-    ).toEqual('1334')
+    ).toEqual('1334\n')
   })
   test('For loop', () => {
     expect(
@@ -26,9 +26,9 @@ describe('Variable Declaration Tests', () => {
           i := 3\
           a += i\
         }\
-        return a;',
+        Println(a)',
       ).output,
-    ).toEqual('25')
+    ).toEqual('25\n')
   })
   test('For loop continue', () => {
     expect(
@@ -42,9 +42,9 @@ describe('Variable Declaration Tests', () => {
           i := 3\
           a += i\
         }\
-        return a;',
+        Println(a)',
       ).output,
-    ).toEqual('19')
+    ).toEqual('19\n')
   })
   test('For loop break', () => {
     expect(
@@ -58,8 +58,8 @@ describe('Variable Declaration Tests', () => {
           i := 3\
           a += i\
         }\
-        return a;',
+        Println(a)',
       ).output,
-    ).toEqual('12')
+    ).toEqual('12\n')
   })
 })

--- a/tests/declaration.test.ts
+++ b/tests/declaration.test.ts
@@ -9,17 +9,17 @@ describe('Variable Declaration Tests', () => {
         'var a int = 3;\
         const b int = 5;\
         const c int = b;\
-        return a+b+c;',
+        Println(a+b+c)',
       ).output,
-    ).toEqual('13')
+    ).toEqual('13\n')
   })
   test('String Variables', () => {
     expect(
       mainRunner(
         'a := "hi";\
         b := "hi2";\
-        return a + b;',
+        Println(a + b)',
       ).output,
-    ).toEqual('"hihi2"')
+    ).toEqual('hihi2\n')
   })
 })

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -10,9 +10,9 @@ describe('Basic Environment Tests', () => {
           b:= a + 3;\
           c := a + b;\
           c *= a;\
-          return a + b + c;',
+          Println(a + b + c)',
       ).output,
-    ).toEqual('36')
+    ).toEqual('36\n')
   })
   test('Number Variables Scoping', () => {
     expect(
@@ -22,8 +22,8 @@ describe('Basic Environment Tests', () => {
           var a int = 1;\
           a = 2;\
         };\
-        return a;',
+        Println(a)',
       ).output,
-    ).toEqual('3')
+    ).toEqual('3\n')
   })
 })

--- a/tests/expression.test.ts
+++ b/tests/expression.test.ts
@@ -4,14 +4,14 @@ import { mainRunner } from './utility'
 
 describe('Basic Expression Tests', () => {
   test('Basic Arithmetic 1', () => {
-    expect(mainRunner('return 5 * -1 + 3 * 4 / 2 + 3').output).toEqual('4')
+    expect(mainRunner('Println(5 * -1 + 3 * 4 / 2 + 3)').output).toEqual('4\n')
   })
   test('Basic Arithmetic 2', () => {
-    expect(mainRunner('return (4+3)*5%(5+3)+2').output).toEqual('5')
+    expect(mainRunner('Println((4+3)*5%(5+3)+2)').output).toEqual('5\n')
   })
   test('Boolean Expression', () => {
-    expect(mainRunner('return (2+1 < 3) || (7 == 9%5 + 15/5)').output).toEqual(
-      'true',
-    )
+    expect(
+      mainRunner('Println((2+1 < 3) || (7 == 9%5 + 15/5))').output,
+    ).toEqual('true\n')
   })
 })

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -9,7 +9,7 @@ describe('Function Type Checking', () => {
     expect(
       mainRunner('var a func(int, int) = func(int, int, int) {}').errorMessage,
     ).toEqual(
-      'Cannot use func(int64, int64, int64) as func(int64, int64) in variable declaration',
+      'Cannot use func(int64, int64, int64) () as func(int64, int64) () in variable declaration',
     )
   })
 

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -58,6 +58,14 @@ describe('Function Type Checking', () => {
       ).errorMessage,
     ).toEqual('Cannot use (string) as (int64) value in return statement.')
   })
+
+  test('Function with too many return values', () => {
+    expect(
+      mainRunner(
+        'f := func(x int) { if x == 1 { return 1 } else { return 1 } }',
+      ).errorMessage,
+    ).toEqual('Too many return values\nhave (int64)\nwant ()')
+  })
 })
 
 describe('Function Execution tests', () => {

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -36,6 +36,28 @@ describe('Function Type Checking', () => {
       mainRunner('f := func(int, int) {}; f(1, "a")').errorMessage,
     ).toEqual('Cannot use string as int64 in argument to function call')
   })
+
+  test('Function missing return', () => {
+    expect(mainRunner('f := func(x int) int { x += 1}').errorMessage).toEqual(
+      'Missing return.',
+    )
+  })
+
+  test('Function with if statement missing return in one branch', () => {
+    expect(
+      mainRunner(
+        'f := func(x int) int { if x == 1 { x += 1 } else { return 1 } }',
+      ).errorMessage,
+    ).toEqual('Missing return.')
+  })
+
+  test('Function with wrong return type', () => {
+    expect(
+      mainRunner(
+        'f := func(x int) int { if x == 1 { return "hi" } else { return 1 } }',
+      ).errorMessage,
+    ).toEqual('Cannot use (string) as (int64) value in return statement.')
+  })
 })
 
 describe('Function Execution tests', () => {

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -47,7 +47,7 @@ describe('Function Execution tests', () => {
       }\
       Println(1 + f(1, 2))',
       ).output,
-    ).toEqual('4')
+    ).toEqual('4\n')
   })
 
   test('Function Declaration', () => {

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -45,7 +45,7 @@ describe('Function Execution tests', () => {
         'f := func(x int, y int) int{\
         return x + y\
       }\
-      return 1 + f(1, 2)',
+      Println(1 + f(1, 2))',
       ).output,
     ).toEqual('4')
   })
@@ -65,11 +65,11 @@ describe('Function Execution tests', () => {
           f := func(x, y int) int {
             return x + y + 100
           }
-          return f(1, 2)
+          Println(f(1, 2))
         }`,
         2048,
       ).output,
-    ).toEqual('103')
+    ).toEqual('103\n')
   })
 
   test('Function assignment in loop', () => {
@@ -85,11 +85,11 @@ describe('Function Execution tests', () => {
               return x + y + i
             }
           }
-          return f(1, 2)
+          Println(f(1, 2))
         }`,
         2048,
       ).output,
-    ).toEqual('8')
+    ).toEqual('8\n')
   })
 
   test('Function assignment in loop and if', () => {
@@ -107,11 +107,11 @@ describe('Function Execution tests', () => {
               }
             }
           }
-          return f(1, 2)
+          Println(f(1, 2))
         }`,
         2048,
       ).output,
-    ).toEqual('103')
+    ).toEqual('103\n')
   })
 
   test('Recursive function', () => {
@@ -127,10 +127,10 @@ describe('Function Execution tests', () => {
       }
       
       func main() {
-        return f(10)
+        Println(f(10))
       }`,
         2048,
       ).output,
-    ).toEqual('10')
+    ).toEqual('10\n')
   })
 })


### PR DESCRIPTION
This PR adds type checking for functions. 

A new type called `ReturnType` is introduced, because Golang allows returning multiple values from a function. Currently, when there is only one type within ReturnType, then the function call is treated as if it returns that type (so that existing code still works).

A function `Println` has been added to allow printing to `stdout`. Note that it should really be `fmt.Println` to follow Golang, but this is not too important. Now all tests check against stdout instead of return, as the main function should not be returning anything.

Future work (another PR):
- When ReturnType has more than one value, we should handle it appropriately. When used in a single-value context, it should throw the error `multiple-value ___ (value of type ___) in single-value context`. It should also be allowed to do variable declaration / assignment with multiple values, such as `a, b, c := f()`.