### PR TITLE
Feat/slices

### DIFF
--- a/src/virtual-machine/compiler/instructions/builtin.ts
+++ b/src/virtual-machine/compiler/instructions/builtin.ts
@@ -1,0 +1,39 @@
+import { Process } from '../../executor/process'
+import { IntegerNode } from '../../heap/types/primitives'
+import { ArrayNode, SliceNode } from '../../heap/types/structures'
+
+import { Instruction } from './base'
+
+/** Takes an object address from the OS, and returns the length of that object. */
+export class BuiltinLenInstruction extends Instruction {
+  constructor() {
+    super('BUILTIN_LEN')
+  }
+
+  override execute(process: Process): void {
+    const node = process.heap.get_value(process.context.popOS())
+    if (node instanceof ArrayNode || node instanceof SliceNode) {
+      const length = node.length()
+      process.context.pushOS(IntegerNode.create(length, process.heap).addr)
+    } else {
+      throw new Error('Unreachable')
+    }
+  }
+}
+
+/** Takes an object address from the OS, and returns the capacity of that object. */
+export class BuiltinCapInstruction extends Instruction {
+  constructor() {
+    super('BUILTIN_CAP')
+  }
+
+  override execute(process: Process): void {
+    const node = process.heap.get_value(process.context.popOS())
+    if (node instanceof ArrayNode || node instanceof SliceNode) {
+      const capacity = node.capacity()
+      process.context.pushOS(IntegerNode.create(capacity, process.heap).addr)
+    } else {
+      throw new Error('Unreachable')
+    }
+  }
+}

--- a/src/virtual-machine/compiler/instructions/index.ts
+++ b/src/virtual-machine/compiler/instructions/index.ts
@@ -1,5 +1,6 @@
 export * from './base'
 export * from './block'
+export * from './builtin'
 export * from './control'
 export * from './funcs'
 export * from './load'

--- a/src/virtual-machine/compiler/instructions/load.ts
+++ b/src/virtual-machine/compiler/instructions/load.ts
@@ -110,7 +110,7 @@ export class LoadSliceInstruction extends Instruction {
     const capacity = process.context.popOSNode(IntegerNode).get_value()
     const length = process.context.popOSNode(IntegerNode).get_value()
     const start = process.context.popOSNode(IntegerNode).get_value()
-    const array = process.context.popOSNode(IntegerNode).get_value()
+    const array = process.context.popOS()
     const sliceNode = SliceNode.create(
       array,
       start,

--- a/src/virtual-machine/compiler/instructions/load.ts
+++ b/src/virtual-machine/compiler/instructions/load.ts
@@ -5,7 +5,7 @@ import {
   IntegerNode,
   StringNode,
 } from '../../heap/types/primitives'
-import { ArrayNode } from '../../heap/types/structures'
+import { ArrayNode, SliceNode } from '../../heap/types/structures'
 import { BoolType, Float64Type, Int64Type, StringType, Type } from '../typing'
 
 import { Instruction } from './base'
@@ -90,6 +90,35 @@ export class LoadArrayElementInstruction extends Instruction {
     }
     const element = array.get_child(index)
     process.context.pushOS(element)
+  }
+}
+
+/**
+ * Creates a slice on the heap, with the following arguments taken from the OS (bottom to top).
+ * - Array address
+ * - Start index of the slice.
+ * - Length of the slice.
+ * - Capacity of the slice.
+ * Pushes the address of the slice back onto the OS.
+ */
+export class LoadSliceInstruction extends Instruction {
+  constructor() {
+    super('LDS')
+  }
+
+  override execute(process: Process): void {
+    const capacity = process.context.popOSNode(IntegerNode).get_value()
+    const length = process.context.popOSNode(IntegerNode).get_value()
+    const start = process.context.popOSNode(IntegerNode).get_value()
+    const array = process.context.popOSNode(IntegerNode).get_value()
+    const sliceNode = SliceNode.create(
+      array,
+      start,
+      length,
+      capacity,
+      process.heap,
+    )
+    process.context.pushOS(sliceNode.addr)
   }
 }
 

--- a/src/virtual-machine/compiler/instructions/load.ts
+++ b/src/virtual-machine/compiler/instructions/load.ts
@@ -182,3 +182,16 @@ export class LoadSliceLengthInstruction extends Instruction {
     process.context.pushOS(IntegerNode.create(length, process.heap).addr)
   }
 }
+
+/** Takes a slice address from the OS, and pushes the capacity of the slice onto OS.  */
+export class LoadSliceCapacityInstruction extends Instruction {
+  constructor() {
+    super('LDSC')
+  }
+
+  override execute(process: Process): void {
+    const slice = process.context.popOSNode(SliceNode)
+    const capacity = slice.get_capacity()
+    process.context.pushOS(IntegerNode.create(capacity, process.heap).addr)
+  }
+}

--- a/src/virtual-machine/compiler/instructions/load.ts
+++ b/src/virtual-machine/compiler/instructions/load.ts
@@ -92,6 +92,25 @@ export class LoadArrayElementInstruction extends Instruction {
     process.context.pushOS(element)
   }
 }
+/** Takes the index, then array from the heap, and loads the element at the index onto the OS.  */
+export class LoadSliceElementInstruction extends Instruction {
+  constructor() {
+    super('LDAE')
+  }
+
+  override execute(process: Process): void {
+    const index = process.context.popOSNode(IntegerNode).get_value()
+    const slice = process.context.popOSNode(SliceNode)
+    const array = new ArrayNode(process.heap, slice.get_array())
+    if (index < 0 || index >= array.get_length()) {
+      throw new Error(
+        `Index out of range [${index}] with length ${array.get_length()}`,
+      )
+    }
+    const element = array.get_child(index)
+    process.context.pushOS(element)
+  }
+}
 
 /**
  * Creates a slice on the heap, with the following arguments taken from the OS (bottom to top).

--- a/src/virtual-machine/compiler/instructions/load.ts
+++ b/src/virtual-machine/compiler/instructions/load.ts
@@ -156,3 +156,29 @@ export class LoadVariableInstruction extends Instruction {
     )
   }
 }
+
+/** Takes an array address from the OS, and pushes the length of the array onto OS.  */
+export class LoadArrayLengthInstruction extends Instruction {
+  constructor() {
+    super('LDAL')
+  }
+
+  override execute(process: Process): void {
+    const array = process.context.popOSNode(ArrayNode)
+    const length = array.get_length()
+    process.context.pushOS(IntegerNode.create(length, process.heap).addr)
+  }
+}
+
+/** Takes a slice address from the OS, and pushes the length of the slice onto OS.  */
+export class LoadSliceLengthInstruction extends Instruction {
+  constructor() {
+    super('LDSL')
+  }
+
+  override execute(process: Process): void {
+    const slice = process.context.popOSNode(SliceNode)
+    const length = slice.get_length()
+    process.context.pushOS(IntegerNode.create(length, process.heap).addr)
+  }
+}

--- a/src/virtual-machine/compiler/instructions/operator.ts
+++ b/src/virtual-machine/compiler/instructions/operator.ts
@@ -1,5 +1,6 @@
 import { Process } from '../../executor/process'
-import { PrimitiveNode } from '../../heap/types/primitives'
+import { IntegerNode, PrimitiveNode } from '../../heap/types/primitives'
+import { ArrayNode, SliceNode } from '../../heap/types/structures'
 
 import { Instruction } from './base'
 
@@ -38,5 +39,69 @@ export class BinaryInstruction extends OpInstruction {
       process.context.popOS(),
     ) as PrimitiveNode
     process.context.pushOS(arg1.apply_binop(arg2, this.op).addr)
+  }
+}
+
+/**
+ * Takes its arguments from the OS, and pushes a new slice onto the OS.
+ * - Node address: Address of the node to slice.
+ * - Low: A number for the starting index (non-integer if the start).
+ * - High: A number for the ending index (non-integer if the end).
+ */
+export class SliceOperationInstruction extends Instruction {
+  constructor() {
+    super('SLICEOP')
+  }
+
+  override execute(process: Process): void {
+    const highNode = process.heap.get_value(process.context.popOS())
+    const lowNode = process.heap.get_value(process.context.popOS())
+    const node = process.heap.get_value(process.context.popOS())
+    const low = lowNode instanceof IntegerNode ? lowNode.get_value() : 0
+    // If high is not provided, its default value will be resolved later on in the code.
+    const high = highNode instanceof IntegerNode ? highNode.get_value() : null
+
+    if (node instanceof ArrayNode) {
+      process.context.pushOS(this.sliceArray(process, node, low, high))
+    } else if (node instanceof SliceNode) {
+      process.context.pushOS(this.sliceSlice(process, node, low, high))
+    } else {
+      throw new Error('Unreachable')
+    }
+  }
+
+  private sliceArray(
+    process: Process,
+    array: ArrayNode,
+    low: number,
+    high: number | null,
+  ): number {
+    low ??= 0
+    high ??= array.length()
+    this.checkSliceRange(low, high, array.length())
+    const newSlice = SliceNode.create(array.addr, low, high, process.heap)
+    return newSlice.addr
+  }
+
+  private sliceSlice(
+    process: Process,
+    slice: SliceNode,
+    low: number,
+    high: number | null,
+  ): number {
+    low ??= 0
+    high ??= slice.capacity()
+    this.checkSliceRange(low, high, slice.capacity())
+    const start = low + slice.start()
+    const end = high + slice.start()
+    const newSlice = SliceNode.create(slice.array(), start, end, process.heap)
+    return newSlice.addr
+  }
+
+  /** Checks that the slice [low:high] is valid on an underlying container with given length. */
+  private checkSliceRange(low: number, high: number, length: number) {
+    if (low < 0 || low > length || high < 0 || high > length || high < low) {
+      throw new Error('Slice bounds out of range')
+    }
   }
 }

--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -6,7 +6,7 @@ import {
   IntegerNode,
   StringNode,
 } from '../../heap/types/primitives'
-import { ArrayNode } from '../../heap/types/structures'
+import { ArrayNode, SliceNode } from '../../heap/types/structures'
 
 export abstract class Type {
   abstract isPrimitive(): boolean
@@ -158,7 +158,7 @@ export class SliceType extends Type {
   }
 
   override defaultNodeCreator(): (heap: Heap) => number {
-    throw new Error('Slice types are not supported.')
+    return (heap) => SliceNode.default(heap).addr
   }
 }
 

--- a/src/virtual-machine/heap/index.ts
+++ b/src/virtual-machine/heap/index.ts
@@ -9,7 +9,7 @@ import {
   StringNode,
   UnassignedNode,
 } from './types/primitives'
-import { ArrayNode, ListNode, StackNode } from './types/structures'
+import { ArrayNode, ListNode, SliceNode, StackNode } from './types/structures'
 import { Memory } from './memory'
 
 export enum TAG {
@@ -27,6 +27,7 @@ export enum TAG {
   FUNC = 11,
   CALLREF = 12,
   ARRAY = 13,
+  SLICE = 14,
 }
 
 export const word_size = 4
@@ -93,6 +94,8 @@ export class Heap {
         return new CallRefNode(this, addr)
       case TAG.ARRAY:
         return new ArrayNode(this, addr)
+      case TAG.SLICE:
+        return new SliceNode(this, addr)
       default:
         throw Error('Unknown Data Type')
     }

--- a/src/virtual-machine/heap/types/context.ts
+++ b/src/virtual-machine/heap/types/context.ts
@@ -73,6 +73,11 @@ export class ContextNode extends BaseNode {
     return this.OS().pop()
   }
 
+  /** Pops the OS and constructs a node with its address.  */
+  popOSNode<T extends BaseNode>(nodeType: new (heap: Heap, addr: number) => T) {
+    return new nodeType(this.heap, this.OS().pop())
+  }
+
   printOS() {
     console.log('OS:')
     for (let i = 0; i < this.OS().sz(); i++) {

--- a/src/virtual-machine/heap/types/structures.ts
+++ b/src/virtual-machine/heap/types/structures.ts
@@ -152,6 +152,15 @@ export class ArrayNode extends BaseNode {
       this.heap.get_child(this.addr + 2, x),
     )
   }
+
+  override toString(): string {
+    const length = this.get_length()
+    const elements = []
+    for (let i = 0; i < length; i++) {
+      elements.push(this.heap.get_value(this.get_child(i)).toString())
+    }
+    return `[${elements.join(' ')}]`
+  }
 }
 
 /**
@@ -172,7 +181,7 @@ export class SliceNode extends BaseNode {
   ): SliceNode {
     const addr = heap.allocate(5)
     heap.set_tag(addr, TAG.SLICE)
-    heap.memory.set_number(array, addr + 1)
+    heap.memory.set_word(array, addr + 1)
     heap.memory.set_number(start, addr + 2)
     heap.memory.set_number(length, addr + 3)
     heap.memory.set_number(capacity, addr + 4)
@@ -184,7 +193,7 @@ export class SliceNode extends BaseNode {
   }
 
   get_array(): number {
-    return this.heap.memory.get_number(this.addr + 1)
+    return this.heap.memory.get_word(this.addr + 1)
   }
 
   get_start(): number {
@@ -211,5 +220,14 @@ export class SliceNode extends BaseNode {
 
   override get_children(): number[] {
     return [this.get_array()]
+  }
+
+  override toString(): string {
+    const length = this.get_length()
+    const elements = []
+    for (let i = 0; i < length; i++) {
+      elements.push(this.heap.get_value(this.get_child(i)).toString())
+    }
+    return `[${elements.join(' ')}]`
   }
 }

--- a/src/virtual-machine/heap/types/structures.ts
+++ b/src/virtual-machine/heap/types/structures.ts
@@ -153,3 +153,63 @@ export class ArrayNode extends BaseNode {
     )
   }
 }
+
+/**
+ * Each SliceNode occupies 5 words.
+ * Word 0: Slice tag.
+ * Word 1: Underlying array address.
+ * Word 2: Start index of this slice (a number).
+ * Word 3: Length (a number).
+ * Word 4: Capacity (a number).
+ */
+export class SliceNode extends BaseNode {
+  static create(
+    array: number,
+    start: number,
+    length: number,
+    capacity: number,
+    heap: Heap,
+  ): SliceNode {
+    const addr = heap.allocate(5)
+    heap.set_tag(addr, TAG.SLICE)
+    heap.memory.set_number(array, addr + 1)
+    heap.memory.set_number(start, addr + 2)
+    heap.memory.set_number(length, addr + 3)
+    heap.memory.set_number(capacity, addr + 4)
+    return new SliceNode(heap, addr)
+  }
+
+  static default(heap: Heap): SliceNode {
+    return SliceNode.create(0, 0, 0, 0, heap)
+  }
+
+  get_array(): number {
+    return this.heap.memory.get_number(this.addr + 1)
+  }
+
+  get_start(): number {
+    return this.heap.memory.get_number(this.addr + 2)
+  }
+
+  get_length(): number {
+    return this.heap.memory.get_number(this.addr + 3)
+  }
+
+  get_capacity(): number {
+    return this.heap.memory.get_number(this.addr + 4)
+  }
+
+  get_child(index: number): number {
+    const array = new ArrayNode(this.heap, this.get_array())
+    return array.get_child(this.get_start() + index)
+  }
+
+  set_child(index: number, address: number) {
+    const array = new ArrayNode(this.heap, this.get_array())
+    array.set_child(this.get_start() + index, address)
+  }
+
+  override get_children(): number[] {
+    return [this.get_array()]
+  }
+}

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -45,6 +45,7 @@
     BuiltinCallToken,
     LiteralValueToken,
     ArrayLiteralToken,
+    SliceLiteralToken,
   } from './tokens'
 
   // Checks whether an identifier is valid (not a reserved keyword).
@@ -304,9 +305,8 @@ OperandName = identifier / QualifiedIdent
 QualifiedIdent = PackageName "." identifier
 
 //* Composite Literals
-//! TODO: Add the other LiteralTypes
-// LiteralType  = StructType / ArrayType / SliceType / MapType / TypeName
 CompositeLit = type:ArrayType _ value:LiteralValue { return new ArrayLiteralToken(type, value) }
+             / type:SliceType _ value:LiteralValue { return new SliceLiteralToken(type, value) }
 LiteralValue = "{" elements:(@ElementList _ ","? _)? "}" { return new LiteralValueToken(elements ?? []) }
 ElementList  = head:KeyedElement rest:(_ "," _ @KeyedElement)* { return [head, ...rest] }
 // Ironically, KeyedElement will not support having a key for our implementation.

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -2,6 +2,7 @@ import { Compiler } from '../../compiler'
 import {
   LoadArrayElementInstruction,
   LoadConstantInstruction,
+  LoadSliceElementInstruction,
 } from '../../compiler/instructions'
 import {
   CallInstruction,
@@ -79,17 +80,25 @@ export class IndexToken extends PrimaryExpressionModifierToken {
 
   override compile(compiler: Compiler, operandType: Type): Type {
     if (operandType instanceof ArrayType) {
-      const indexType = this.expression.compile(compiler)
-      if (!(indexType instanceof Int64Type)) {
-        throw new Error(
-          `Invalid argument: Index has type ${indexType} but must be an integer`,
-        )
-      }
+      this.compileIndex(compiler)
       compiler.instructions.push(new LoadArrayElementInstruction())
+      return operandType.element
+    } else if (operandType instanceof SliceType) {
+      this.compileIndex(compiler)
+      compiler.instructions.push(new LoadSliceElementInstruction())
       return operandType.element
     } else {
       throw Error(
         `Invalid operation: Cannot index a variable of type ${operandType}`,
+      )
+    }
+  }
+
+  private compileIndex(compiler: Compiler) {
+    const indexType = this.expression.compile(compiler)
+    if (!(indexType instanceof Int64Type)) {
+      throw new Error(
+        `Invalid argument: Index has type ${indexType} but must be an integer`,
       )
     }
   }

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -3,6 +3,7 @@ import {
   LoadArrayElementInstruction,
   LoadArrayLengthInstruction,
   LoadConstantInstruction,
+  LoadSliceCapacityInstruction,
   LoadSliceElementInstruction,
   LoadSliceLengthInstruction,
 } from '../../compiler/instructions'
@@ -205,9 +206,26 @@ export class BuiltinCallToken extends Token {
     if (this.name === 'make') return this.compileMake(compiler)
     else if (this.name === 'Println') return this.compilePrintln(compiler)
     else if (this.name === 'len') return this.compileLen(compiler)
+    else if (this.name === 'cap') return this.compileCap(compiler)
     else {
       throw new Error(`Builtin function ${this.name} is not yet implemented.`)
     }
+  }
+
+  private compileCap(compiler: Compiler): Type {
+    if (this.args.length !== 1) {
+      this.throwArgumentLengthError('cap', 1, this.args.length)
+    }
+    const argType = this.args[0].compile(compiler)
+    if (argType instanceof ArrayType) {
+      // The capacity of an array is the length of the array.
+      compiler.instructions.push(new LoadArrayLengthInstruction())
+    } else if (argType instanceof SliceType) {
+      compiler.instructions.push(new LoadSliceCapacityInstruction())
+    } else {
+      this.throwArgumentTypeError('cap', argType)
+    }
+    return new Int64Type()
   }
 
   private compileLen(compiler: Compiler): Type {

--- a/src/virtual-machine/parser/tokens/literals.ts
+++ b/src/virtual-machine/parser/tokens/literals.ts
@@ -186,7 +186,6 @@ export class LiteralValueToken extends Token {
         new LoadArrayInstruction(sliceLength),
         new LoadConstantInstruction(0, new Int64Type()),
         new LoadConstantInstruction(sliceLength, new Int64Type()),
-        new LoadConstantInstruction(sliceLength, new Int64Type()),
         new LoadSliceInstruction(),
       )
     } else {

--- a/src/virtual-machine/parser/tokens/literals.ts
+++ b/src/virtual-machine/parser/tokens/literals.ts
@@ -6,6 +6,7 @@ import {
   LoadConstantInstruction,
   LoadDefaultInstruction,
   LoadFuncInstruction,
+  LoadSliceInstruction,
   ReturnInstruction,
 } from '../../compiler/instructions'
 import {
@@ -13,6 +14,7 @@ import {
   Float64Type,
   Int64Type,
   ReturnType,
+  SliceType,
   StringType,
   Type,
 } from '../../compiler/typing'
@@ -20,7 +22,7 @@ import {
 import { Token } from './base'
 import { BlockToken } from './block'
 import { ExpressionToken } from './expressions'
-import { ArrayTypeToken, FunctionTypeToken } from './type'
+import { ArrayTypeToken, FunctionTypeToken, SliceTypeToken } from './type'
 
 export abstract class LiteralToken extends Token {
   constructor(public value: number | string) {
@@ -167,16 +169,7 @@ export class LiteralValueToken extends Token {
       }
 
       for (const element of this.elements) {
-        if (element instanceof LiteralValueToken) {
-          element.compileWithType(compiler, type.element)
-        } else {
-          const actualType = element.compile(compiler)
-          if (!type.element.equals(actualType)) {
-            throw new Error(
-              `Cannot use ${actualType} as ${type.element} value in array literal.`,
-            )
-          }
-        }
+        this.compileElement(compiler, type.element, element, 'array literal')
       }
       for (let i = 0; i < type.length - this.elements.length; i++) {
         // Ran out of literal values, use the default values.
@@ -184,8 +177,40 @@ export class LiteralValueToken extends Token {
       }
 
       compiler.instructions.push(new LoadArrayInstruction(type.length))
+    } else if (type instanceof SliceType) {
+      for (const element of this.elements) {
+        this.compileElement(compiler, type.element, element, 'slice literal')
+      }
+      const sliceLength = this.elements.length
+      compiler.instructions.push(
+        new LoadArrayInstruction(sliceLength),
+        new LoadConstantInstruction(0, new Int64Type()),
+        new LoadConstantInstruction(sliceLength, new Int64Type()),
+        new LoadConstantInstruction(sliceLength, new Int64Type()),
+        new LoadSliceInstruction(),
+      )
     } else {
       throw new Error('Parser Bug: Type of literal value is not supported.')
+    }
+  }
+
+  /** Compile an element and check that it matches the given type.
+   * typeName is the name of the structure (e.g. array literal) for the error message. */
+  private compileElement(
+    compiler: Compiler,
+    type: Type,
+    element: LiteralValueToken | ExpressionToken,
+    typeName: string,
+  ) {
+    if (element instanceof LiteralValueToken) {
+      element.compileWithType(compiler, type)
+    } else {
+      const actualType = element.compile(compiler)
+      if (!type.equals(actualType)) {
+        throw new Error(
+          `Cannot use ${actualType} as ${type} value in ${typeName}.`,
+        )
+      }
     }
   }
 }
@@ -200,6 +225,21 @@ export class ArrayLiteralToken extends Token {
 
   override compile(compiler: Compiler): Type {
     const type = this.arrayType.compile(compiler)
+    this.body.compileWithType(compiler, type)
+    return type
+  }
+}
+
+export class SliceLiteralToken extends Token {
+  constructor(
+    public sliceType: SliceTypeToken,
+    public body: LiteralValueToken,
+  ) {
+    super('slice_literal')
+  }
+
+  override compile(compiler: Compiler): Type {
+    const type = this.sliceType.compile(compiler)
     this.body.compileWithType(compiler, type)
     return type
   }

--- a/src/virtual-machine/parser/tokens/type.ts
+++ b/src/virtual-machine/parser/tokens/type.ts
@@ -71,7 +71,7 @@ export class ArrayTypeToken extends TypeToken {
     super()
   }
 
-  override compile(compiler: Compiler): Type {
+  override compile(compiler: Compiler): ArrayType {
     return new ArrayType(this.element.compile(compiler), this.length.getValue())
   }
 }
@@ -81,7 +81,7 @@ export class SliceTypeToken extends TypeToken {
     super()
   }
 
-  override compile(compiler: Compiler): Type {
+  override compile(compiler: Compiler): SliceType {
     return new SliceType(this.element.compile(compiler))
   }
 }

--- a/tests/slice.test.ts
+++ b/tests/slice.test.ts
@@ -73,4 +73,10 @@ describe('Slice Execution', () => {
       mainRunner('a := [][]int{{1}, {2}, {3}}; Println(len(a))').output,
     ).toEqual('3\n')
   })
+
+  test('Slice capacity works.', () => {
+    expect(
+      mainRunner('a := [][]int{{1}, {2}, {3}}; Println(cap(a))').output,
+    ).toEqual('3\n')
+  })
 })

--- a/tests/slice.test.ts
+++ b/tests/slice.test.ts
@@ -36,6 +36,12 @@ describe('Slice Type Checking', () => {
       mainRunner('a := []int{1, 2, 3, 4}; Println(len(1))').errorMessage,
     ).toEqual('Invalid argument: (int64) for len')
   })
+
+  test('Slicing invalid types should fail.', () => {
+    expect(mainRunner('a := 1; b := a[:]').errorMessage).toEqual(
+      'Invalid operation: Cannot slice int64',
+    )
+  })
 })
 
 describe('Slice Execution', () => {
@@ -78,5 +84,26 @@ describe('Slice Execution', () => {
     expect(
       mainRunner('a := [][]int{{1}, {2}, {3}}; Println(cap(a))').output,
     ).toEqual('3\n')
+  })
+
+  test('Slicing works.', () => {
+    expect(
+      mainRunner(`a := [4]int{0, 1, 2, 3}
+      b := a[:]
+      Println(b)
+      b = b[2:]
+      Println(b)
+      c := b[1:]
+      Println(c)
+      c = c[1:]
+      Println(c)`).output,
+    ).toEqual('[0 1 2 3]\n[2 3]\n[3]\n[]\n')
+  })
+
+  test('Slicing with out of bounds range should error.', () => {
+    expect(
+      mainRunner(`a := [4]int{0, 1, 2, 3}
+      b := a[4:5]`).errorMessage,
+    ).toEqual('Slice bounds out of range')
   })
 })

--- a/tests/slice.test.ts
+++ b/tests/slice.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest'
+
+import { mainRunner } from './utility'
+
+describe('Slice Type Checking', () => {
+  test('Slice literal must have the same type as the declared type.', () => {
+    expect(
+      mainRunner('var a []int = []int{1, "wrong type", 3}').errorMessage,
+    ).toEqual('Cannot use string as int64 value in slice literal.')
+  })
+
+  test('Slice indexing with non integer type should fail.', () => {
+    expect(
+      mainRunner('var a []int = []int{1, 2, 3}; Println(a[1.2])').errorMessage,
+    ).toEqual('Invalid argument: Index has type float64 but must be an integer')
+  })
+})
+
+describe('Slice Execution', () => {
+  test('Slice indexing with valid index works.', () => {
+    expect(
+      mainRunner('var a []string = []string{"a", "b", "c"}\n Println(a[2])')
+        .output,
+    ).toEqual('c\n')
+  })
+
+  test('Slice indexing with negative index fails.', () => {
+    expect(
+      mainRunner('var a []string = []string{"a", "b", "c"}\n Println(a[-1])')
+        .errorMessage,
+    ).toEqual('Index out of range [-1] with length 3')
+  })
+
+  test('Slice indexing with out of range index fails.', () => {
+    expect(
+      mainRunner('var a []string = []string{"a", "b", "c"}\n Println(a[3])')
+        .errorMessage,
+    ).toEqual('Index out of range [3] with length 3')
+  })
+
+  test('Nested slices work.', () => {
+    expect(
+      mainRunner(
+        'a := [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}; Println(a[1][2])',
+      ).output,
+    ).toEqual('6\n')
+  })
+})

--- a/tests/slice.test.ts
+++ b/tests/slice.test.ts
@@ -14,6 +14,28 @@ describe('Slice Type Checking', () => {
       mainRunner('var a []int = []int{1, 2, 3}; Println(a[1.2])').errorMessage,
     ).toEqual('Invalid argument: Index has type float64 but must be an integer')
   })
+
+  test('Slice len with too little arguments fails', () => {
+    expect(
+      mainRunner('a := []int{1, 2, 3, 4}; Println(len())').errorMessage,
+    ).toEqual(
+      'Invalid operation: not enough arguments for len (expected 1, found 0)',
+    )
+  })
+
+  test('Slice len with too many arguments fails', () => {
+    expect(
+      mainRunner('a := []int{1, 2, 3, 4}; Println(len(a, a))').errorMessage,
+    ).toEqual(
+      'Invalid operation: too many arguments for len (expected 1, found 2)',
+    )
+  })
+
+  test('Slice len with wrong type', () => {
+    expect(
+      mainRunner('a := []int{1, 2, 3, 4}; Println(len(1))').errorMessage,
+    ).toEqual('Invalid argument: (int64) for len')
+  })
 })
 
 describe('Slice Execution', () => {
@@ -44,5 +66,11 @@ describe('Slice Execution', () => {
         'a := [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}; Println(a[1][2])',
       ).output,
     ).toEqual('6\n')
+  })
+
+  test('Slice len works.', () => {
+    expect(
+      mainRunner('a := [][]int{{1}, {2}, {3}}; Println(len(a))').output,
+    ).toEqual('3\n')
   })
 })


### PR DESCRIPTION
This PR adds the slice type and slice operation (both type checking and runtime).

<img width="1124" alt="Screenshot 2024-04-06 at 2 09 18 PM" src="https://github.com/huajun07/go-virtual-machine/assets/30954848/0f29342c-efd2-4424-89ac-ca6e53332300">

Additions:
- Added slice type.
- Added slice operation for arrays and slices.
- Added `len` and `cap` builtin functions for arrays and slices.
- Added printing for arrays and slices.

Future extensions (in future PRs):
- Some of the error messages are getting repetitive, we should organize all the common errors into one utility class, and also differentiate between syntax, compile and runtime error.
- Implement `append` builtin function for slice types. Currently our slices cannot grow beyond its underlying array.
- Implement `make` builtin function for slice types.
- Golang allows string slices, but this is low priority for us to add.