### PR TITLE
Feat/wait

### DIFF
--- a/src/virtual-machine/compiler/instructions/operator.ts
+++ b/src/virtual-machine/compiler/instructions/operator.ts
@@ -1,6 +1,10 @@
 import { Process } from '../../executor/process'
 import { ArrayNode, SliceNode } from '../../heap/types/array'
-import { IntegerNode, PrimitiveNode } from '../../heap/types/primitives'
+import {
+  IntegerNode,
+  PrimitiveNode,
+  StringNode,
+} from '../../heap/types/primitives'
 
 import { Instruction } from './base'
 
@@ -103,5 +107,21 @@ export class SliceOperationInstruction extends Instruction {
     if (low < 0 || low > length || high < 0 || high > length || high < low) {
       throw new Error('Slice bounds out of range')
     }
+  }
+}
+
+/**
+ * Takes its operand and identifier string from the OS,
+ * and selects the given identifier from the operand.
+ */
+export class SelectorOperationInstruction extends Instruction {
+  constructor() {
+    super('SELECTOP')
+  }
+
+  override execute(process: Process): void {
+    const identifier = process.context.popOSNode(StringNode).get_value()
+    const node = process.heap.get_value(process.context.popOS())
+    node.select(process, identifier)
   }
 }

--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -21,6 +21,13 @@ export abstract class Type {
 
   /** Returns a function that creates a default node of this type on the heap, and returns its address. */
   abstract defaultNodeCreator(): (heap: Heap) => number
+
+  /** Returns the type of selecting an identifier on the given type. */
+  select(identifier: string): Type {
+    throw new Error(
+      `undefined (type ${this} has no field or method ${identifier})`,
+    )
+  }
 }
 
 /** This type represents things that don't have an associated type, like statements. */
@@ -213,6 +220,39 @@ export class FunctionType extends Type {
 
   override defaultNodeCreator(): (heap: Heap) => number {
     return (heap) => FuncNode.default(heap).addr
+  }
+}
+
+export class MethodType extends Type {
+  constructor(
+    public receiver: Type,
+    public parameters: ParameterType[],
+    public results: ReturnType,
+  ) {
+    super()
+  }
+
+  override isPrimitive(): boolean {
+    return false
+  }
+
+  override defaultNodeCreator(): (heap: Heap) => number {
+    return (heap) => FuncNode.default(heap).addr
+  }
+
+  override toString(): string {
+    const parametersString = TypeUtility.arrayToString(this.parameters)
+    return `func (${this.receiver}) (${parametersString}) ${this.results}`
+  }
+
+  override equals(t: Type): boolean {
+    return (
+      t instanceof MethodType &&
+      this.receiver.equals(t.receiver) &&
+      this.parameters.length === t.parameters.length &&
+      this.parameters.every((p, index) => p.equals(t.parameters[index])) &&
+      this.results.equals(t.results)
+    )
   }
 }
 

--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -294,6 +294,29 @@ export class ReturnType extends Type {
   }
 }
 
+export class PackageType extends Type {
+  constructor(public name: string, public types: Record<string, Type>) {
+    super()
+  }
+
+  override isPrimitive(): boolean {
+    return false
+  }
+
+  override toString(): string {
+    return `package ${this.name}`
+  }
+
+  override equals(t: Type): boolean {
+    return t instanceof PackageType && t.name === this.name
+  }
+
+  override defaultNodeCreator(): (_heap: Heap) => number {
+    // Do nothing, as our implementation does not support user created packages.
+    throw new Error('Unreachable')
+  }
+}
+
 export const TypeUtility = {
   // Similar to Array.toString(), but adds a space after each comma.
   arrayToString(types: Type[] | null) {

--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -299,6 +299,13 @@ export class PackageType extends Type {
     super()
   }
 
+  get(identifier: string): Type {
+    if (!(identifier in this.types)) {
+      throw new Error(`undefined: ${this.name}.${identifier}`)
+    }
+    return this.types[identifier]
+  }
+
   override isPrimitive(): boolean {
     return false
   }

--- a/src/virtual-machine/compiler/typing/packages.ts
+++ b/src/virtual-machine/compiler/typing/packages.ts
@@ -1,0 +1,28 @@
+import { Heap } from '../../heap'
+import { WaitGroupNode } from '../../heap/types/waitGroup'
+
+import { PackageType, Type } from '.'
+
+export class WaitGroupType extends Type {
+  override isPrimitive(): boolean {
+    return false
+  }
+
+  override toString(): string {
+    return `sync.WaitGroup`
+  }
+
+  override equals(t: Type): boolean {
+    return t instanceof WaitGroupType
+  }
+
+  override defaultNodeCreator(): (heap: Heap) => number {
+    return (heap) => WaitGroupNode.default(heap).addr
+  }
+}
+
+export const builtinPackages = {
+  sync: new PackageType('sync', {
+    WaitGroup: new WaitGroupType(),
+  }),
+}

--- a/src/virtual-machine/compiler/typing/packages.ts
+++ b/src/virtual-machine/compiler/typing/packages.ts
@@ -1,7 +1,14 @@
 import { Heap } from '../../heap'
 import { WaitGroupNode } from '../../heap/types/waitGroup'
 
-import { PackageType, Type } from '.'
+import {
+  Int64Type,
+  MethodType,
+  PackageType,
+  ParameterType,
+  ReturnType,
+  Type,
+} from '.'
 
 export class WaitGroupType extends Type {
   override isPrimitive(): boolean {
@@ -18,6 +25,23 @@ export class WaitGroupType extends Type {
 
   override defaultNodeCreator(): (heap: Heap) => number {
     return (heap) => WaitGroupNode.default(heap).addr
+  }
+
+  override select(identifier: string): Type {
+    if (identifier === 'Add') {
+      return new MethodType(
+        new WaitGroupType(),
+        [new ParameterType(null, new Int64Type())],
+        new ReturnType([]),
+      )
+    } else if (identifier === 'Done') {
+      return new MethodType(new WaitGroupType(), [], new ReturnType([]))
+    } else if (identifier === 'Wait') {
+      return new MethodType(new WaitGroupType(), [], new ReturnType([]))
+    }
+    throw new Error(
+      `.${identifier} undefined (type ${this} has no field or method ${identifier})`,
+    )
   }
 }
 

--- a/src/virtual-machine/heap/index.ts
+++ b/src/virtual-machine/heap/index.ts
@@ -2,7 +2,7 @@ import { ArrayNode, SliceNode } from './types/array'
 import { ChannelNode, ChannelReqNode, ReqInfoNode } from './types/channel'
 import { ContextNode } from './types/context'
 import { EnvironmentNode, FrameNode } from './types/environment'
-import { CallRefNode, FuncNode } from './types/func'
+import { CallRefNode, FuncNode, MethodNode } from './types/func'
 import { LinkedListEntryNode, LinkedListNode } from './types/linkedlist'
 import {
   BoolNode,
@@ -14,6 +14,7 @@ import {
 } from './types/primitives'
 import { QueueListNode, QueueNode } from './types/queue'
 import { StackListNode, StackNode } from './types/stack'
+import { WaitGroupNode } from './types/waitGroup'
 import { Memory } from './memory'
 
 export enum TAG {
@@ -40,6 +41,7 @@ export enum TAG {
   REQ_INFO = 20,
   SLICE = 21,
   WAIT_GROUP = 22,
+  METHOD = 23,
 }
 
 export const word_size = 4
@@ -125,6 +127,10 @@ export class Heap {
         return new ChannelReqNode(this, addr)
       case TAG.REQ_INFO:
         return new ReqInfoNode(this, addr)
+      case TAG.WAIT_GROUP:
+        return new WaitGroupNode(this, addr)
+      case TAG.METHOD:
+        return new MethodNode(this, addr)
       default:
         // return new UnassignedNode(this, addr)
         throw Error('Unknown Data Type')

--- a/src/virtual-machine/heap/index.ts
+++ b/src/virtual-machine/heap/index.ts
@@ -39,6 +39,7 @@ export enum TAG {
   CHANNEL_REQ = 19,
   REQ_INFO = 20,
   SLICE = 21,
+  WAIT_GROUP = 22,
 }
 
 export const word_size = 4

--- a/src/virtual-machine/heap/types/base.ts
+++ b/src/virtual-machine/heap/types/base.ts
@@ -1,3 +1,4 @@
+import { Process } from '../../executor/process'
 import { Heap } from '..'
 
 export abstract class BaseNode {
@@ -7,7 +8,18 @@ export abstract class BaseNode {
     this.heap = heap
     this.addr = addr
   }
+
   get_children(): number[] {
     return []
+  }
+
+  // Calls the select operator on this node.
+  select(_process: Process, _identifier: string): void {
+    throw new Error('Unreachable')
+  }
+
+  // Calls the method of this node, with arguments on the OS.
+  handleMethodCall(_process: Process, _identifier: string): void {
+    throw new Error('Unreachable')
   }
 }

--- a/src/virtual-machine/heap/types/waitGroup.ts
+++ b/src/virtual-machine/heap/types/waitGroup.ts
@@ -33,6 +33,9 @@ export class WaitGroupNode extends BaseNode {
   }
 
   set_count(new_count: number): void {
+    if (new_count < 0) {
+      throw new Error('sync: negative WaitGroup counter.')
+    }
     this.heap.memory.set_number(new_count, this.addr + 1)
   }
 
@@ -65,9 +68,6 @@ export class WaitGroupNode extends BaseNode {
 
   handleDone(process: Process): void {
     process.context.popOS()
-    if (this.count() === 0) {
-      throw new Error('sync: negative WaitGroup counter')
-    }
     this.set_count(this.count() - 1)
     if (this.count() === 0) {
       while (this.queue().sz()) {

--- a/src/virtual-machine/heap/types/waitGroup.ts
+++ b/src/virtual-machine/heap/types/waitGroup.ts
@@ -73,6 +73,7 @@ export class WaitGroupNode extends BaseNode {
       while (this.queue().sz()) {
         const context = new ContextNode(this.heap, this.queue().pop())
         context.set_blocked(false)
+        this.heap.contexts.push(context.addr)
       }
     }
   }

--- a/src/virtual-machine/heap/types/waitGroup.ts
+++ b/src/virtual-machine/heap/types/waitGroup.ts
@@ -1,0 +1,68 @@
+import { Heap, TAG } from '..'
+
+import { BaseNode } from './base'
+import { ContextNode } from './context'
+import { QueueNode } from './queue'
+
+/**
+ * Each WaitGroupNode occupies 3 words.
+ * Word 0: Wait Group tag.
+ * Word 1: A non-negative number, representing how number of .Add - number of .Done calls.
+ * Word 2: The address to a queue of waiting contexts.
+ */
+export class WaitGroupNode extends BaseNode {
+  static create(heap: Heap): WaitGroupNode {
+    const addr = heap.allocate(3)
+    heap.set_tag(addr, TAG.WAIT_GROUP)
+    heap.temp_push(addr)
+    heap.memory.set_number(0, addr + 1)
+    heap.memory.set_word(QueueNode.create(heap).addr, addr + 2)
+    return new WaitGroupNode(heap, addr)
+  }
+
+  static default(heap: Heap): WaitGroupNode {
+    return WaitGroupNode.create(heap)
+  }
+
+  count(): number {
+    return this.heap.memory.get_number(this.addr + 1)
+  }
+
+  set_count(new_count: number): void {
+    this.heap.memory.set_number(new_count, this.addr + 1)
+  }
+
+  queue(): QueueNode {
+    return new QueueNode(this.heap, this.heap.memory.get_word(this.addr + 2))
+  }
+
+  handleAdd(): void {
+    this.set_count(this.count() + 1)
+  }
+
+  handleDone(): void {
+    if (this.count() === 0) {
+      throw new Error('sync: negative WaitGroup counter')
+    }
+    this.set_count(this.count() - 1)
+    if (this.count() === 0) {
+      for (const contextAddr of this.queue().get_vals()) {
+        const context = new ContextNode(this.heap, contextAddr)
+        context.set_blocked(false)
+      }
+    }
+  }
+
+  handleWait(context: number): void {
+    this.queue().push(context)
+  }
+
+  override get_children(): number[] {
+    return [this.queue().addr]
+  }
+
+  override toString(): string {
+    //! TODO: Figure out what the string format of Golang's WaitGroup is.
+    throw new Error('Unimplemented')
+  }
+}

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -46,6 +46,7 @@
     LiteralValueToken,
     ArrayLiteralToken,
     SliceLiteralToken,
+    QualifiedIdentifierToken,
   } from './tokens'
 
   // Checks whether an identifier is valid (not a reserved keyword).
@@ -166,6 +167,7 @@ Type     = @TypeName / TypeLit / "(" _ Type _ ")"
 //! TODO (P1): Support qualified identifiers for TypeName.
 TypeName = iden:identifier &{ return PrimitiveTypeToken.isPrimitive(iden.identifier) }
            { return new PrimitiveTypeToken(iden.identifier) }
+         / @QualifiedIdent
 TypeLit  = ArrayType / StructType / PointerType / FunctionType / InterfaceType / SliceType / MapType / ChannelType
 
 //* Array Types
@@ -302,7 +304,7 @@ BasicLit    = float_lit / int_lit / string_lit
 OperandName = identifier / QualifiedIdent
 
 //* Qualified Identifiers
-QualifiedIdent = PackageName "." identifier
+QualifiedIdent = pkg:PackageName "." iden:identifier { return new QualifiedIdentifierToken(pkg.identifier, iden.identifier) }
 
 //* Composite Literals
 CompositeLit = type:ArrayType _ value:LiteralValue { return new ArrayLiteralToken(type, value) }

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -366,16 +366,16 @@ rel_op      = "==" { return BinaryOperator.fromSource("equal") } /
               "<=" { return BinaryOperator.fromSource("less_or_equal") } /
               ">" { return BinaryOperator.fromSource("greater") } /
               ">=" { return BinaryOperator.fromSource("greater_or_equal") }
-add_op      = "+" { return BinaryOperator.fromSource("sum") } /
-              "-" { return BinaryOperator.fromSource("difference") } /
-              "|" { return BinaryOperator.fromSource("bitwise_or") } /
-              "^" { return BinaryOperator.fromSource("bitwise_xor") }
-mul_op      = "*" { return BinaryOperator.fromSource("product") } /
-              "/" { return BinaryOperator.fromSource("quotient") } /
+add_op      = "+" !"+" { return BinaryOperator.fromSource("sum") } /
+              "-" !"-" { return BinaryOperator.fromSource("difference") } /
+              "|" !"|" { return BinaryOperator.fromSource("bitwise_or") } /
+              "^" !"^" { return BinaryOperator.fromSource("bitwise_xor") }
+mul_op      = "*" !"*" { return BinaryOperator.fromSource("product") } /
+              "/" !"/" { return BinaryOperator.fromSource("quotient") } /
               "%" { return BinaryOperator.fromSource("remainder") } /
               "<<" { return BinaryOperator.fromSource("left_shift") } /
               ">>" { return BinaryOperator.fromSource("right_shift") } /
-              "&" { return BinaryOperator.fromSource("bitwise_and") } /
+              "&" !"&" { return BinaryOperator.fromSource("bitwise_and") } /
               "&^" { return BinaryOperator.fromSource("bit_clear") }
 disjunct_op = "||" { return BinaryOperator.fromSource("conditional_or") }
 conjunct_op = "&&" { return BinaryOperator.fromSource("conditional_and") }

--- a/src/virtual-machine/parser/tokens/identifier.ts
+++ b/src/virtual-machine/parser/tokens/identifier.ts
@@ -1,6 +1,6 @@
 import { Compiler } from '../../compiler'
 import { LoadVariableInstruction } from '../../compiler/instructions'
-import { Type } from '../../compiler/typing'
+import { PackageType, Type } from '../../compiler/typing'
 
 import { Token } from './base'
 
@@ -16,5 +16,20 @@ export class IdentifierToken extends Token {
   }
 }
 
-//! TODO (P2): QualifiedIdentifier is not supported for now,
-//! because idk how to resolve its parsing ambiguity with selector.
+export class QualifiedIdentifierToken extends Token {
+  constructor(public pkg: string, public identifier: string) {
+    super('qualified_identifier')
+  }
+
+  override compile(compiler: Compiler): Type {
+    const pkg = compiler.type_environment.get(this.pkg)
+    if (!(pkg instanceof PackageType)) {
+      throw new Error(`${this} is not a type`)
+    }
+    return pkg.get(this.identifier)
+  }
+
+  override toString(): string {
+    return `${this.pkg}.${this.identifier}`
+  }
+}

--- a/tests/waitGroup.test.ts
+++ b/tests/waitGroup.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'vitest'
+
+import { runCode } from '../src/virtual-machine'
+
+describe('Wait Group Type Checking', () => {
+  test('Wait groups should not work without importing sync.', () => {
+    const code = `
+    package main
+
+    func main() {
+      var a sync.WaitGroup
+    }
+    `
+    expect(runCode(code, 2048).errorMessage).toEqual('Variable sync not found')
+  })
+
+  test('Assinging a variable of another type to WaitGroup should fail.', () => {
+    const code = `
+    package main
+    import "sync"
+    func main() {
+      var a sync.WaitGroup = "hello"
+    }
+    `
+    expect(runCode(code, 2048).errorMessage).toEqual(
+      'Cannot use string as sync.WaitGroup in variable declaration',
+    )
+  })
+
+  test('Calling .Add() with too many arguments should fail.', () => {
+    const code = `
+    package main
+    import "sync"
+    func main() {
+      var a sync.WaitGroup
+      a.Add(1, 2)
+    }
+    `
+    expect(runCode(code, 2048).errorMessage).toEqual(
+      'Too many arguments in function call\nhave (int64, int64)\nwant (int64)',
+    )
+  })
+})
+
+describe('Wait Group Execution', () => {
+  test('Making the WaitGroup counter negative by adding should panic.', () => {
+    const code = `
+    package main
+    import "sync"
+    func main() {
+      var a sync.WaitGroup
+      a.Add(-5)
+    }
+    `
+    expect(runCode(code, 2048).errorMessage).toEqual(
+      'sync: negative WaitGroup counter.',
+    )
+  })
+
+  test('Making the WaitGroup counter negative by Done should panic.', () => {
+    const code = `
+    package main
+    import "sync"
+    func main() {
+      var a sync.WaitGroup
+      a.Add(1)
+      a.Done()
+      a.Done()
+    }
+    `
+    expect(runCode(code, 2048).errorMessage).toEqual(
+      'sync: negative WaitGroup counter.',
+    )
+  })
+
+  test('Waiting works.', () => {
+    const code = `
+    package main
+    import "sync"
+    func main() {
+      count := 0
+      var wg sync.WaitGroup
+      for i := 0; i < 1000; i++ {
+        wg.Add(1)
+        go func() {
+          count++
+          wg.Done()
+        }()
+      }
+      wg.Wait()
+      Println(count)
+    }
+    `
+    expect(runCode(code, 65536).output).toEqual('1000\n')
+  })
+})


### PR DESCRIPTION
This PR adds `sync.WaitGroup`.

- Added packages, but they are very hardcoded for now and not easily extendible to other packages (for example, they only support qualified identifiers that are types, which works because `sync.WaitGroup` is a type).
- `WaitGroup` is implemented with a new Node type that stores its own counter, and a queue of waiting contexts. Once the counter reaches 0, everything in the queue gets unblocked.
- Fixed a bunch of cases where expressions were parsed as `BinaryOperator`. For example, `a++ \n f()` was wrongly parsed as `a +  +(f(n))`, where the second `+` is the unary plus.

`defer` statements will be added in a future PR.