### PR TITLE
Feat/defer

### DIFF
--- a/src/virtual-machine/executor/process.ts
+++ b/src/virtual-machine/executor/process.ts
@@ -19,12 +19,12 @@ export class Process {
     this.contexts = this.heap.contexts
     this.context = new ContextNode(this.heap, this.contexts.peek())
     this.stdout = ''
+    console.log(this.heap.mem_left)
     const base_frame = FrameNode.create(0, this.heap)
     const base_env = EnvironmentNode.create([base_frame.addr], false, this.heap)
     this.context.set_E(base_env.addr)
-    const randomSeed = 'hi'
-    //  Math.random().toString(36).substring(2)
-    // console.log('Random Seed', randomSeed)
+    const randomSeed = Math.random().toString(36).substring(2)
+    console.log('Random Seed', randomSeed)
     this.generator = seedrandom.default(randomSeed)
   }
 
@@ -44,7 +44,6 @@ export class Process {
         const instr = this.instructions[this.context.incr_PC()]
         // console.log('ctx:', this.context.addr)
         // console.log('Instr:', instr, this.context.PC() - 1)
-        // console.log(this.heap.mem_left)
         instr.execute(this)
         // this.context.printOS()
         // this.context.printRTS()

--- a/src/virtual-machine/heap/index.ts
+++ b/src/virtual-machine/heap/index.ts
@@ -354,7 +354,8 @@ export class Heap {
     if (addr === -1) return
     if (this.is_marked(addr)) return
     this.set_mark(addr, true)
-    const children = this.get_value(addr).get_children()
+    const val = this.get_value(addr)
+    const children = val.get_children()
     for (const child of children) {
       this.mark(child)
     }
@@ -362,6 +363,7 @@ export class Heap {
 
   mark_and_sweep() {
     console.log('CLEAN')
+    // console.trace()
     const roots: number[] = [
       this.contexts.addr,
       this.temp_roots.addr,

--- a/src/virtual-machine/heap/index.ts
+++ b/src/virtual-machine/heap/index.ts
@@ -2,7 +2,13 @@ import { ArrayNode, SliceNode } from './types/array'
 import { ChannelNode, ChannelReqNode, ReqInfoNode } from './types/channel'
 import { ContextNode } from './types/context'
 import { EnvironmentNode, FrameNode } from './types/environment'
-import { CallRefNode, FuncNode, MethodNode } from './types/func'
+import {
+  CallRefNode,
+  DeferFuncNode,
+  DeferMethodNode,
+  FuncNode,
+  MethodNode,
+} from './types/func'
 import { LinkedListEntryNode, LinkedListNode } from './types/linkedlist'
 import {
   BoolNode,
@@ -42,6 +48,8 @@ export enum TAG {
   SLICE = 21,
   WAIT_GROUP = 22,
   METHOD = 23,
+  DEFER_FUNC = 24,
+  DEFER_METHOD = 25,
 }
 
 export const word_size = 4
@@ -131,6 +139,10 @@ export class Heap {
         return new WaitGroupNode(this, addr)
       case TAG.METHOD:
         return new MethodNode(this, addr)
+      case TAG.DEFER_FUNC:
+        return new DeferFuncNode(this, addr)
+      case TAG.DEFER_METHOD:
+        return new DeferMethodNode(this, addr)
       default:
         // return new UnassignedNode(this, addr)
         throw Error('Unknown Data Type')

--- a/src/virtual-machine/heap/types/channel.ts
+++ b/src/virtual-machine/heap/types/channel.ts
@@ -11,6 +11,7 @@ export class ChannelNode extends BaseNode {
     heap.set_tag(addr, TAG.CHANNEL)
     heap.memory.set_number(buffer, addr + 1)
     heap.temp_push(addr)
+    for (let i = 2; i <= 4; i++) heap.memory.set_number(-1, addr + i)
     const buffer_queue = QueueNode.create(heap)
     heap.memory.set_word(buffer_queue.addr, addr + 2)
     const recv_wait_queue = LinkedListNode.create(heap)

--- a/src/virtual-machine/heap/types/context.ts
+++ b/src/virtual-machine/heap/types/context.ts
@@ -98,7 +98,9 @@ export class ContextNode extends BaseNode {
   }
 
   pushRTS(addr: number) {
+    this.heap.temp_push(addr)
     this.RTS().push(addr)
+    this.heap.temp_pop()
   }
 
   popRTS(): number {
@@ -147,7 +149,9 @@ export class ContextNode extends BaseNode {
 
   pushDeferStack(): void {
     const stack = StackNode.create(this.heap)
+    this.heap.temp_push(stack.addr)
     this.deferStack().push(stack.addr)
+    this.heap.temp_pop()
   }
 
   peekDeferStack(): StackNode {

--- a/src/virtual-machine/heap/types/environment.ts
+++ b/src/virtual-machine/heap/types/environment.ts
@@ -26,11 +26,10 @@ export class FrameNode extends BaseNode {
 
 export class EnvironmentNode extends BaseNode {
   static create(frames: number[], for_block: boolean, heap: Heap) {
-    const addr = heap.allocate(frames.length + 2)
+    const addr = heap.allocate(frames.length + 1)
     heap.set_tag(addr, TAG.ENVIRONMENT)
     heap.memory.set_bits(for_block ? 1 : 0, addr, 1, 16)
-    // TODO: Add Defer Stuff
-    heap.set_children(addr, frames, 2)
+    heap.set_children(addr, frames, 1)
     return new EnvironmentNode(heap, addr)
   }
 
@@ -41,7 +40,7 @@ export class EnvironmentNode extends BaseNode {
   }
 
   get_frame(index: number) {
-    return new FrameNode(this.heap, this.heap.get_child(this.addr + 2, index))
+    return new FrameNode(this.heap, this.heap.get_child(this.addr + 1, index))
   }
 
   get_var(frame_idx: number, var_idx: number) {
@@ -53,11 +52,10 @@ export class EnvironmentNode extends BaseNode {
   }
 
   get_frames(): number[] {
-    return this.heap.get_children(this.addr, 2)
+    return this.heap.get_children(this.addr, 1)
   }
 
   override get_children(): number[] {
-    // TODO: When defer is added this needs to be 1 instead
-    return this.heap.get_children(this.addr, 2)
+    return this.heap.get_children(this.addr, 1)
   }
 }

--- a/src/virtual-machine/heap/types/func.ts
+++ b/src/virtual-machine/heap/types/func.ts
@@ -56,6 +56,7 @@ export class MethodNode extends BaseNode {
     const addr = heap.allocate(3)
     heap.set_tag(addr, TAG.METHOD)
     heap.temp_push(addr)
+    heap.memory.set_number(-1, addr + 2)
     heap.memory.set_word(receiver, addr + 1)
     heap.memory.set_word(StringNode.create(identifier, heap).addr, addr + 2)
     heap.temp_pop()
@@ -94,6 +95,7 @@ export class DeferFuncNode extends BaseNode {
     const addr = process.heap.allocate(3)
     process.heap.temp_push(addr)
     process.heap.set_tag(addr, TAG.DEFER_FUNC)
+    process.heap.memory.set_word(-1, addr + 2)
 
     const stack = StackNode.create(process.heap)
     process.heap.memory.set_word(stack.addr, addr + 2)
@@ -141,6 +143,7 @@ export class DeferMethodNode extends BaseNode {
     const addr = process.heap.allocate(3)
     process.heap.set_tag(addr, TAG.DEFER_METHOD)
     process.heap.temp_push(addr)
+    process.heap.memory.set_word(-1, addr + 2)
 
     const stack = StackNode.create(process.heap)
     process.heap.memory.set_word(stack.addr, addr + 2)

--- a/src/virtual-machine/heap/types/linkedlist.ts
+++ b/src/virtual-machine/heap/types/linkedlist.ts
@@ -7,6 +7,7 @@ export class LinkedListNode extends BaseNode {
     const addr = heap.allocate(3)
     heap.set_tag(addr, TAG.LINKED_LIST)
     heap.temp_push(addr)
+    for (let i = 1; i <= 2; i++) heap.memory.set_number(-1, addr + i)
     const head = LinkedListEntryNode.create(-1, heap)
     heap.memory.set_number(head.addr, addr + 1)
     const tail = LinkedListEntryNode.create(-1, heap)

--- a/src/virtual-machine/heap/types/primitives.ts
+++ b/src/virtual-machine/heap/types/primitives.ts
@@ -136,6 +136,7 @@ export class StringNode extends PrimitiveNode {
     const addr = heap.allocate(2)
     heap.set_tag(addr, TAG.STRING)
     heap.temp_push(addr)
+    heap.memory.set_number(-1, addr + 1)
     const list_addr = heap.allocate(Math.ceil((str.length + 1) / word_size) + 1)
     heap.set_tag(list_addr, TAG.STRING_LIST)
     heap.memory.set_word(list_addr, addr + 1)

--- a/src/virtual-machine/heap/types/queue.ts
+++ b/src/virtual-machine/heap/types/queue.ts
@@ -7,6 +7,7 @@ export class QueueNode extends BaseNode {
     const addr = heap.allocate(2)
     heap.set_tag(addr, TAG.QUEUE)
     heap.temp_push(addr)
+    heap.memory.set_number(-1, addr + 1)
     const list = QueueListNode.create(heap)
     heap.temp_pop()
     heap.memory.set_word(list.addr, addr + 1)

--- a/src/virtual-machine/heap/types/stack.ts
+++ b/src/virtual-machine/heap/types/stack.ts
@@ -7,6 +7,7 @@ export class StackNode extends BaseNode {
     const addr = heap.allocate(2)
     heap.set_tag(addr, TAG.STACK)
     if (heap.temp_roots) heap.temp_push(addr)
+    heap.memory.set_number(-1, addr + 1)
     const list = StackListNode.create(heap)
     if (heap.temp_roots) heap.temp_pop()
     heap.memory.set_word(list.addr, addr + 1)
@@ -41,7 +42,7 @@ export class StackNode extends BaseNode {
     return this.list().get_sz()
   }
   override get_children(): number[] {
-    return [this.heap.memory.get_word(this.addr + 1)]
+    return [this.list().addr]
   }
 }
 

--- a/src/virtual-machine/heap/types/waitGroup.ts
+++ b/src/virtual-machine/heap/types/waitGroup.ts
@@ -18,6 +18,7 @@ export class WaitGroupNode extends BaseNode {
     const addr = heap.allocate(3)
     heap.set_tag(addr, TAG.WAIT_GROUP)
     heap.temp_push(addr)
+    heap.memory.set_number(-1, addr + 2)
     heap.memory.set_number(0, addr + 1)
     heap.memory.set_word(QueueNode.create(heap).addr, addr + 2)
     heap.temp_pop()

--- a/src/virtual-machine/parser/tokens/source_file.ts
+++ b/src/virtual-machine/parser/tokens/source_file.ts
@@ -51,7 +51,10 @@ export class ImportToken extends Token {
   override compile(compiler: Compiler): Type {
     const pkg = this.importPath.getValue()
     if (pkg in builtinPackages) {
-      compiler.type_environment.addType(pkg, builtinPackages[pkg])
+      compiler.type_environment.addType(
+        pkg,
+        builtinPackages[pkg as keyof typeof builtinPackages],
+      )
     }
     return new NoType()
   }

--- a/src/virtual-machine/parser/tokens/statement.ts
+++ b/src/virtual-machine/parser/tokens/statement.ts
@@ -351,9 +351,22 @@ export class DeferStatementToken extends Token {
     super('defer')
   }
 
-  override compile(_compiler: Compiler): Type {
-    // TODO: Implement
+  override compile(compiler: Compiler): Type {
+    if (!this.isFunctionCall()) {
+      throw new Error('Expression in defer must be function call.')
+    }
+
+    this.expression.compile(compiler)
+
     return new NoType()
+  }
+
+  private isFunctionCall(): boolean {
+    if (!(this.expression instanceof PrimaryExpressionToken)) return false
+    const modifiers = this.expression.rest ?? []
+    if (modifiers.length === 0) return false
+    if (!(modifiers[modifiers.length - 1] instanceof CallToken)) return false
+    return true
   }
 }
 

--- a/src/virtual-machine/parser/tokens/statement.ts
+++ b/src/virtual-machine/parser/tokens/statement.ts
@@ -2,6 +2,8 @@ import { Compiler } from '../../compiler'
 import {
   BinaryInstruction,
   BlockInstruction,
+  CallInstruction,
+  DeferredCallInstruction,
   DoneInstruction,
   ExitBlockInstruction,
   ForkInstruction,
@@ -357,6 +359,9 @@ export class DeferStatementToken extends Token {
     }
 
     this.expression.compile(compiler)
+    const call = compiler.instructions[compiler.instructions.length - 1]
+    compiler.instructions[compiler.instructions.length - 1] =
+      DeferredCallInstruction.fromCallInstruction(call as CallInstruction)
 
     return new NoType()
   }

--- a/tests/defer.test.ts
+++ b/tests/defer.test.ts
@@ -43,6 +43,6 @@ describe('Defer Execution', () => {
       Println(count)
     }
     `
-    expect(runCode(code, 65536).output).toEqual('1000\n')
+    expect(runCode(code, 131072).output).toEqual('1000\n')
   })
 })

--- a/tests/defer.test.ts
+++ b/tests/defer.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'vitest'
+
+import { runCode } from '../src/virtual-machine'
+
+import { mainRunner } from './utility'
+
+describe('Defer Type Checking', () => {
+  test('Defer on non call should fail.', () => {
+    const code = `
+    defer "hello"
+    `
+    expect(mainRunner(code).errorMessage).toEqual(
+      'Expression in defer must be function call.',
+    )
+  })
+})
+
+describe('Defer Execution', () => {
+  test('Defer runs in order', () => {
+    const code = `
+    defer func(){ Println("!!!") }()
+    defer func(){ Println("world") }()
+    Println("hello")
+    `
+    expect(mainRunner(code).output).toEqual('hello\nworld\n!!!\n')
+  })
+
+  test('Defer with wait groups work', () => {
+    const code = `
+    package main
+    import "sync"
+    func main() {
+      count := 0
+      var wg sync.WaitGroup
+      for i := 0; i < 1000; i++ {
+        wg.Add(1)
+        go func() {
+          defer wg.Done()
+          count++
+        }()
+      }
+      wg.Wait()
+      Println(count)
+    }
+    `
+    expect(runCode(code, 65536).output).toEqual('1000\n')
+  })
+})

--- a/tests/defer.test.ts
+++ b/tests/defer.test.ts
@@ -43,6 +43,6 @@ describe('Defer Execution', () => {
       Println(count)
     }
     `
-    expect(runCode(code, 131072).output).toEqual('1000\n')
+    expect(runCode(code, 2048).output).toEqual('1000\n')
   })
 })

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -163,4 +163,10 @@ describe('Function Execution tests', () => {
       ).output,
     ).toEqual('10\n')
   })
+
+  test('Calling a function twice.', () => {
+    expect(mainRunner('f := func(){ Println(1) }; f(); f()').output).toEqual(
+      '1\n1\n',
+    )
+  })
 })

--- a/tests/heap.test.ts
+++ b/tests/heap.test.ts
@@ -36,7 +36,7 @@ describe('Heap Tests', () => {
     expect(() => FrameNode.create(0, heap)).toThrow(Error)
   })
   test('Mark And Sweep 2', () => {
-    const heap = new Heap(52)
+    const heap = new Heap(50)
     const context = new ContextNode(heap, heap.contexts.peek())
     const base_frame = FrameNode.create(0, heap)
     const base_env = EnvironmentNode.create([base_frame.addr], false, heap)

--- a/tests/heap.test.ts
+++ b/tests/heap.test.ts
@@ -26,17 +26,17 @@ describe('Heap Tests', () => {
     expect(heap.memory.get_bits(1, 29, 6)).toEqual(1)
   })
   test('Get Set Bits 4', () => {
-    const heap = new Heap(38)
+    const heap = new Heap(44)
     heap.memory.set_bits(2, 3, 5, 1)
     heap.memory.set_bits(3, 3, 29, 6)
     expect(heap.memory.get_bits(3, 5, 1)).toEqual(2)
   })
   test('Mark And Sweep', () => {
-    const heap = new Heap(38)
+    const heap = new Heap(44)
     expect(() => FrameNode.create(0, heap)).toThrow(Error)
   })
   test('Mark And Sweep 2', () => {
-    const heap = new Heap(46)
+    const heap = new Heap(52)
     const context = new ContextNode(heap, heap.contexts.peek())
     const base_frame = FrameNode.create(0, heap)
     const base_env = EnvironmentNode.create([base_frame.addr], false, heap)

--- a/tests/waitGroup.test.ts
+++ b/tests/waitGroup.test.ts
@@ -91,6 +91,6 @@ describe('Wait Group Execution', () => {
       Println(count)
     }
     `
-    expect(runCode(code, 65536).output).toEqual('1000\n')
+    expect(runCode(code, 2048).output).toEqual('1000\n')
   })
 })


### PR DESCRIPTION
This PR adds `defer` statements.

- Defers are implemented by having each context keep track of a stack of "defer stack"s:
  - For each function call, we create and push a new defer stack.
  - Each time we encounter a defer, we created a DeferFuncNode/DeferMethodNode, and push it onto the latest stack.
  - Each time we return, we pop the latest defer stack, and go through all the deferred calls.

In addition:
- Refactored RTS and E. They are now merged, so that RTS now is what was previously `[...RTS, E]`. This fixed a bug where `context.popRTS` was popping and returning the second most recent environment, instead of the current environment.

~~Lastly, there is a GC bug somewhere (that is maybe most likely not introduced in this PR) that deletes live nodes, because some testcases get a heap error that is resolved upon increasing heap size.~~

Note this bug is fixed:
- When garbage collecting while you are creating an inner class (i.e. `StackListNode` from `StackNode`) the initial addr of the `StackListNode` is not yet set, but is treated as one of the children of the `StackNode` in the garbage collection leading to rubbish values.
- This is prevented by first setting the addr to -1