### PR TITLE
Refactor: Environment

### DIFF
--- a/src/virtual-machine/compiler/environment.ts
+++ b/src/virtual-machine/compiler/environment.ts
@@ -12,15 +12,16 @@ class CompileEnvironment {
   }
 
   find_var(name: string) {
-    let frame_idx = this.frames.length - 1
-    while (frame_idx >= 0) {
-      let var_idx = this.frames[frame_idx].length - 1
+    let frame_idx = 0
+    const frame_sz = this.frames.length - 1
+    while (frame_sz >= frame_idx) {
+      let var_idx = this.frames[frame_sz - frame_idx].length - 1
       while (var_idx >= 0) {
-        if (this.frames[frame_idx][var_idx] === name)
+        if (this.frames[frame_sz - frame_idx][var_idx] === name)
           return [frame_idx, var_idx]
         var_idx--
       }
-      frame_idx--
+      frame_idx++
     }
     throw Error('Unable to find variable: ' + name)
   }
@@ -31,7 +32,7 @@ class CompileEnvironment {
       if (var_name === name) throw Error('Variable already declared')
     }
     const new_len = this.frames[frame_idx].push(name)
-    return [frame_idx, new_len - 1]
+    return [0, new_len - 1]
   }
 
   get_frame() {

--- a/src/virtual-machine/compiler/instructions/control.ts
+++ b/src/virtual-machine/compiler/instructions/control.ts
@@ -41,8 +41,7 @@ export class ExitLoopInstruction extends JumpInstruction {
   }
 
   override execute(process: Process): void {
-    while (process.context.E().if_for_block()) {
-      // TODO: Implement defer in popRTS
+    while (!process.context.E().if_for_block()) {
       process.context.popRTS()
     }
     process.context.set_PC(this.addr)

--- a/src/virtual-machine/executor/process.ts
+++ b/src/virtual-machine/executor/process.ts
@@ -21,7 +21,12 @@ export class Process {
     this.stdout = ''
     console.log(this.heap.mem_left)
     const base_frame = FrameNode.create(0, this.heap)
-    const base_env = EnvironmentNode.create([base_frame.addr], false, this.heap)
+    const base_env = EnvironmentNode.create(
+      base_frame.addr,
+      [],
+      false,
+      this.heap,
+    )
     this.context.set_E(base_env.addr)
     const randomSeed = Math.random().toString(36).substring(2)
     console.log('Random Seed', randomSeed)

--- a/src/virtual-machine/heap/index.ts
+++ b/src/virtual-machine/heap/index.ts
@@ -322,7 +322,7 @@ export class Heap {
   }
 
   set_end_child(addr: number, index: number) {
-    this.memory.set_word(-1, addr + index)
+    this.memory.set_number(-1, addr + index)
   }
 
   set_children(addr: number, children: number[], offset = 1) {

--- a/src/virtual-machine/heap/types/context.ts
+++ b/src/virtual-machine/heap/types/context.ts
@@ -120,10 +120,14 @@ export class ContextNode extends BaseNode {
       const addr = this.RTS().get_idx(i)
       const val = addr === -1 ? -1 : this.heap.get_value(addr)
       //   console.log(val)
-      console.log(val, val === -1 ? -1 : val.get_children())
+      let for_block = false
+      if (val instanceof EnvironmentNode && val.if_for_block()) for_block = true
+      console.log(
+        val,
+        val === -1 ? -1 : val.get_children().slice(1),
+        for_block ? 'for block' : '',
+      )
     }
-    const val = this.E()
-    console.log('E:', val, val.get_children())
   }
 
   fork() {

--- a/src/virtual-machine/heap/types/environment.ts
+++ b/src/virtual-machine/heap/types/environment.ts
@@ -25,37 +25,68 @@ export class FrameNode extends BaseNode {
 }
 
 export class EnvironmentNode extends BaseNode {
-  static create(frames: number[], for_block: boolean, heap: Heap) {
-    const addr = heap.allocate(frames.length + 1)
+  // [metadata] [frame] [...parents]
+  // Note parents is terminated by -1 in the heap or by end of node block capacity
+  static create(
+    frame: number,
+    parents: number[],
+    for_block: boolean,
+    heap: Heap,
+  ) {
+    const addr = heap.allocate(parents.length + 2)
     heap.set_tag(addr, TAG.ENVIRONMENT)
     heap.memory.set_bits(for_block ? 1 : 0, addr, 1, 16)
-    heap.set_children(addr, frames, 1)
+    heap.memory.set_word(frame, addr + 1)
+    heap.set_children(addr, parents, 2)
     return new EnvironmentNode(heap, addr)
   }
 
   extend_env(frame: number, for_block = false) {
-    const frames = this.get_frames()
-    frames.push(frame)
-    return EnvironmentNode.create(frames, for_block, this.heap)
+    const parents = [this.addr]
+    let cur_par = new EnvironmentNode(this.heap, this.addr)
+    let new_par = cur_par.get_parent(parents.length - 1)
+    while (new_par) {
+      parents.push(new_par.addr)
+      cur_par = new_par
+      new_par = cur_par.get_parent(parents.length - 1)
+    }
+    return EnvironmentNode.create(frame, parents, for_block, this.heap)
   }
 
-  get_frame(index: number) {
-    return new FrameNode(this.heap, this.heap.get_child(this.addr + 1, index))
+  get_frame() {
+    return new FrameNode(this.heap, this.heap.memory.get_word(this.addr + 1))
+  }
+
+  get_frame_idx(idx: number): FrameNode {
+    if (idx === 0) return this.get_frame()
+    const lvl = Math.floor(Math.log2(idx))
+    const par = this.get_parent(lvl)
+    if (!par) throw Error('Execution Error: Invalid frame index')
+    return par.get_frame_idx(idx - 2 ** lvl)
+  }
+
+  get_parent(idx: number) {
+    if (
+      idx + 2 >= this.heap.get_size(this.addr) ||
+      this.heap.memory.get_number(this.addr + idx + 2) === -1
+    )
+      return undefined
+    else
+      return new EnvironmentNode(
+        this.heap,
+        this.heap.memory.get_number(this.addr + idx + 2),
+      )
   }
 
   get_var(frame_idx: number, var_idx: number) {
-    return this.get_frame(frame_idx).get_idx(var_idx)
+    return this.get_frame_idx(frame_idx).get_idx(var_idx)
   }
 
   if_for_block() {
     return this.heap.memory.get_bits(this.addr, 1, 16) === 1
   }
 
-  get_frames(): number[] {
-    return this.heap.get_children(this.addr, 1)
-  }
-
   override get_children(): number[] {
-    return this.heap.get_children(this.addr, 1)
+    return [this.get_frame().addr, ...this.heap.get_children(this.addr, 2)]
   }
 }

--- a/tests/heap.test.ts
+++ b/tests/heap.test.ts
@@ -39,7 +39,7 @@ describe('Heap Tests', () => {
     const heap = new Heap(50)
     const context = new ContextNode(heap, heap.contexts.peek())
     const base_frame = FrameNode.create(0, heap)
-    const base_env = EnvironmentNode.create([base_frame.addr], false, heap)
+    const base_env = EnvironmentNode.create(base_frame.addr, [], false, heap)
     context.set_E(base_env.addr)
     heap.allocate(2)
     heap.allocate(2)


### PR DESCRIPTION
# Refactor
- Make each environment contain exact one frame and maintain pointers to its ancestors of power 2 levels.
- We can then find the environment through binary lifting
- Note: Reversed the `frame_idx` (i.e. last frame is index 0) to assist with the binary lifting

# Bug fix
- Fixed bug where `ExitLoopInstruction` pops when the current environment is a for loop block