### PR TITLE
feat: add true and false keywords

### DIFF
--- a/src/virtual-machine/parser/tokens/source_file.ts
+++ b/src/virtual-machine/parser/tokens/source_file.ts
@@ -2,9 +2,11 @@ import { Compiler } from '../../compiler'
 import {
   BlockInstruction,
   CallInstruction,
+  LoadConstantInstruction,
   LoadVariableInstruction,
+  StoreInstruction,
 } from '../../compiler/instructions'
-import { NoType, Type } from '../../compiler/typing'
+import { BoolType, NoType, Type } from '../../compiler/typing'
 import { builtinPackages } from '../../compiler/typing/packages'
 
 import { Token } from './base'
@@ -21,14 +23,24 @@ export class SourceFileToken extends Token {
   }
 
   override compile(compiler: Compiler): Type {
+    // Setup.
     const global_block = new BlockInstruction('GLOBAL')
     compiler.instructions.push(global_block)
     compiler.context.push_env()
     compiler.type_environment = compiler.type_environment.extend()
+
+    // Compile imports.
     for (const imp of this.imports ?? []) imp.compile(compiler)
+
+    // Declare builtin constants for `true` and `false`.
+    this.predeclareConstants(compiler)
+
+    // Compile top level declarations.
     for (const declaration of this.declarations || []) {
       declaration.compile(compiler)
     }
+
+    // Call main function.
     const [frame_idx, var_idx] = compiler.context.env.find_var('main')
     compiler.instructions.push(
       new LoadVariableInstruction(frame_idx, var_idx, 'main'),
@@ -40,6 +52,31 @@ export class SourceFileToken extends Token {
     )
     global_block.set_identifiers(vars)
     return new NoType()
+  }
+
+  private predeclareConstants(compiler: Compiler): void {
+    const constants = [
+      {
+        name: 'true',
+        loadInstruction: new LoadConstantInstruction(true, new BoolType()),
+        type: new BoolType(),
+      },
+      {
+        name: 'false',
+        loadInstruction: new LoadConstantInstruction(false, new BoolType()),
+        type: new BoolType(),
+      },
+    ]
+    for (const constant of constants) {
+      const { name, loadInstruction, type } = constant
+      const [frame_idx, var_idx] = compiler.context.env.declare_var(name)
+      compiler.instructions.push(
+        loadInstruction,
+        new LoadVariableInstruction(frame_idx, var_idx, name),
+        new StoreInstruction(),
+      )
+      compiler.type_environment.addType(name, type)
+    }
   }
 }
 

--- a/tests/declaration.test.ts
+++ b/tests/declaration.test.ts
@@ -13,6 +13,7 @@ describe('Variable Declaration Tests', () => {
       ).output,
     ).toEqual('13\n')
   })
+
   test('String Variables', () => {
     expect(
       mainRunner(
@@ -21,5 +22,31 @@ describe('Variable Declaration Tests', () => {
         Println(a + b)',
       ).output,
     ).toEqual('hihi2\n')
+  })
+
+  test('Boolean constants true and false are predeclared', () => {
+    const code = `
+    if false {
+      Println("false")
+    }
+    if true {
+      Println("true")
+    }
+    `
+    expect(mainRunner(code).output).toEqual('true\n')
+  })
+
+  test('Boolean constants true and false can be shadowed by local declaration', () => {
+    const code = `
+    true := false
+    false := true
+    if false {
+      Println("false")
+    }
+    if true {
+      Println("true")
+    }
+    `
+    expect(mainRunner(code).output).toEqual('')
   })
 })


### PR DESCRIPTION
This PR adds the declaration of constants `true` and `false`, so that code like this now works (previously it would have complained that variable `true` is not found).

```go
func main() {
  a := true
  if true {
  }
}
```

Our implementation follows Golang's. `true` and `false` can be shadowed by local variables. For example, the following is valid Golang and outputs nothing.

```go
func main() {
  true := false
  false := true
  if true { Println("hello") }
  if false { Println("world") }
}
```