### PR TITLE
Feat/packages

### DIFF
--- a/src/virtual-machine/compiler/instructions/funcs.ts
+++ b/src/virtual-machine/compiler/instructions/funcs.ts
@@ -6,7 +6,6 @@ import {
   FuncNode,
   MethodNode,
 } from '../../heap/types/func'
-import { IntegerNode } from '../../heap/types/primitives'
 
 import { Instruction } from './base'
 
@@ -161,31 +160,5 @@ export class ReturnInstruction extends Instruction {
     const callRef = process.heap.get_value(process.context.popRTS())
     if (!(callRef instanceof CallRefNode)) throw new Error('Unreachable')
     process.context.set_PC(callRef.PC())
-  }
-}
-
-/**
- * Takes the top of the OS to be the number of arguments.
- * Then takes its arguments from the OS (in reverse order), and prints them out.
- */
-export class PrintInstruction extends Instruction {
-  constructor() {
-    super('PRINT')
-  }
-
-  override execute(process: Process): void {
-    const numOfArgs = new IntegerNode(
-      process.heap,
-      process.context.popOS(),
-    ).get_value()
-    const argAddresses = []
-    for (let i = 0; i < numOfArgs; i++) {
-      argAddresses.push(process.context.popOS())
-    }
-    for (let i = numOfArgs - 1; i >= 0; i--) {
-      const string = process.heap.get_value(argAddresses[i]).toString()
-      process.print(string)
-      process.print(i > 0 ? ' ' : '\n')
-    }
   }
 }

--- a/src/virtual-machine/compiler/instructions/funcs.ts
+++ b/src/virtual-machine/compiler/instructions/funcs.ts
@@ -59,7 +59,7 @@ export class CallInstruction extends Instruction {
       process.context.set_PC(func.PC())
     } else {
       const receiver = func.receiver()
-      receiver.handleMethodCall(process, func.identifier())
+      receiver.handleMethodCall(process, func.identifier(), this.args)
     }
   }
 }
@@ -138,10 +138,13 @@ export class ReturnInstruction extends Instruction {
         const methodNode = deferNode.methodNode()
         process.context.pushOS(methodNode.addr)
         process.context.pushOS(methodNode.receiverAddr())
+        const argCount = deferNode.stack().sz()
         while (deferNode.stack().sz()) {
           process.context.pushOS(deferNode.stack().pop())
         }
-        methodNode.receiver().handleMethodCall(process, methodNode.identifier())
+        methodNode
+          .receiver()
+          .handleMethodCall(process, methodNode.identifier(), argCount)
 
         // Since methods are hardcoded and don't behave like functions, they don't jump back to an address.
         // Manually decrement PC here so that the next executor step will return to this instruction.

--- a/src/virtual-machine/compiler/instructions/load.ts
+++ b/src/virtual-machine/compiler/instructions/load.ts
@@ -1,5 +1,6 @@
 import { Process } from '../../executor/process'
 import { ArrayNode, SliceNode } from '../../heap/types/array'
+import { FmtPkgNode } from '../../heap/types/fmt'
 import {
   BoolNode,
   FloatNode,
@@ -166,5 +167,22 @@ export class LoadVariableInstruction extends Instruction {
     process.context.pushOS(
       process.context.E().get_var(this.frame_idx, this.var_idx),
     )
+  }
+}
+
+/**
+ * Takes a package name (string literal) from the OS and loads the corresponding package node back onto the OS.
+ * Currently this is only implemented for `fmt`, as it is the only package requiring runtime values.
+ */
+export class LoadPackageInstruction extends Instruction {
+  constructor() {
+    super('LDP')
+  }
+
+  override execute(process: Process): void {
+    const packageName = process.context.popOSNode(StringNode).get_value()
+    if (packageName !== 'fmt') throw new Error('Unreachable')
+    const packageNode = FmtPkgNode.default(process.heap)
+    process.context.pushOS(packageNode.addr)
   }
 }

--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -200,7 +200,7 @@ export class FunctionType extends Type {
   constructor(
     public parameters: ParameterType[],
     public results: ReturnType,
-    public variadic: boolean = true,
+    public variadic: boolean = false,
   ) {
     super()
   }

--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -1,6 +1,7 @@
 import { Heap } from '../../heap'
 import { ArrayNode, SliceNode } from '../../heap/types/array'
 import { ChannelNode } from '../../heap/types/channel'
+import { PkgNode } from '../../heap/types/fmt'
 import { FuncNode } from '../../heap/types/func'
 import {
   BoolNode,
@@ -196,7 +197,11 @@ export class ParameterType extends Type {
 }
 
 export class FunctionType extends Type {
-  constructor(public parameters: ParameterType[], public results: ReturnType) {
+  constructor(
+    public parameters: ParameterType[],
+    public results: ReturnType,
+    public variadic: boolean = true,
+  ) {
     super()
   }
 
@@ -306,13 +311,6 @@ export class PackageType extends Type {
     super()
   }
 
-  get(identifier: string): Type {
-    if (!(identifier in this.types)) {
-      throw new Error(`undefined: ${this.name}.${identifier}`)
-    }
-    return this.types[identifier]
-  }
-
   override isPrimitive(): boolean {
     return false
   }
@@ -326,8 +324,14 @@ export class PackageType extends Type {
   }
 
   override defaultNodeCreator(): (_heap: Heap) => number {
-    // Do nothing, as our implementation does not support user created packages.
-    throw new Error('Unreachable')
+    return (heap) => PkgNode.default(heap).addr
+  }
+
+  override select(identifier: string): Type {
+    if (!(identifier in this.types)) {
+      throw new Error(`undefined: ${this.name}.${identifier}`)
+    }
+    return this.types[identifier]
   }
 }
 

--- a/src/virtual-machine/compiler/typing/index.ts
+++ b/src/virtual-machine/compiler/typing/index.ts
@@ -223,39 +223,6 @@ export class FunctionType extends Type {
   }
 }
 
-export class MethodType extends Type {
-  constructor(
-    public receiver: Type,
-    public parameters: ParameterType[],
-    public results: ReturnType,
-  ) {
-    super()
-  }
-
-  override isPrimitive(): boolean {
-    return false
-  }
-
-  override defaultNodeCreator(): (heap: Heap) => number {
-    return (heap) => FuncNode.default(heap).addr
-  }
-
-  override toString(): string {
-    const parametersString = TypeUtility.arrayToString(this.parameters)
-    return `func (${this.receiver}) (${parametersString}) ${this.results}`
-  }
-
-  override equals(t: Type): boolean {
-    return (
-      t instanceof MethodType &&
-      this.receiver.equals(t.receiver) &&
-      this.parameters.length === t.parameters.length &&
-      this.parameters.every((p, index) => p.equals(t.parameters[index])) &&
-      this.results.equals(t.results)
-    )
-  }
-}
-
 export class ChannelType extends Type {
   constructor(
     public element: Type,

--- a/src/virtual-machine/compiler/typing/packages.ts
+++ b/src/virtual-machine/compiler/typing/packages.ts
@@ -2,8 +2,8 @@ import { Heap } from '../../heap'
 import { WaitGroupNode } from '../../heap/types/waitGroup'
 
 import {
+  FunctionType,
   Int64Type,
-  MethodType,
   PackageType,
   ParameterType,
   ReturnType,
@@ -29,15 +29,14 @@ export class WaitGroupType extends Type {
 
   override select(identifier: string): Type {
     if (identifier === 'Add') {
-      return new MethodType(
-        new WaitGroupType(),
+      return new FunctionType(
         [new ParameterType(null, new Int64Type())],
         new ReturnType([]),
       )
     } else if (identifier === 'Done') {
-      return new MethodType(new WaitGroupType(), [], new ReturnType([]))
+      return new FunctionType([], new ReturnType([]))
     } else if (identifier === 'Wait') {
-      return new MethodType(new WaitGroupType(), [], new ReturnType([]))
+      return new FunctionType([], new ReturnType([]))
     }
     throw new Error(
       `.${identifier} undefined (type ${this} has no field or method ${identifier})`,

--- a/src/virtual-machine/heap/index.ts
+++ b/src/virtual-machine/heap/index.ts
@@ -4,6 +4,7 @@ import { ArrayNode, SliceNode } from './types/array'
 import { ChannelNode, ChannelReqNode, ReqInfoNode } from './types/channel'
 import { ContextNode } from './types/context'
 import { EnvironmentNode, FrameNode } from './types/environment'
+import { FmtPkgNode, PkgNode } from './types/fmt'
 import {
   CallRefNode,
   DeferFuncNode,
@@ -52,6 +53,8 @@ export enum TAG {
   METHOD = 23,
   DEFER_FUNC = 24,
   DEFER_METHOD = 25,
+  PKG = 26,
+  FMT_PKG = 27,
 }
 
 export const word_size = 4
@@ -148,6 +151,10 @@ export class Heap {
         return new DeferFuncNode(this, addr)
       case TAG.DEFER_METHOD:
         return new DeferMethodNode(this, addr)
+      case TAG.PKG:
+        return new PkgNode(this, addr)
+      case TAG.FMT_PKG:
+        return new FmtPkgNode(this, addr)
       default:
         // return new UnassignedNode(this, addr)
         throw Error('Unknown Data Type')

--- a/src/virtual-machine/heap/types/base.ts
+++ b/src/virtual-machine/heap/types/base.ts
@@ -19,7 +19,11 @@ export abstract class BaseNode {
   }
 
   // Calls the method of this node, with arguments on the OS.
-  handleMethodCall(_process: Process, _identifier: string): void {
+  handleMethodCall(
+    _process: Process,
+    _identifier: string,
+    _argCount: number,
+  ): void {
     throw new Error('Unreachable')
   }
 }

--- a/src/virtual-machine/heap/types/fmt.ts
+++ b/src/virtual-machine/heap/types/fmt.ts
@@ -1,0 +1,73 @@
+import { Process } from '../../executor/process'
+import { Heap, TAG } from '..'
+
+import { BaseNode } from './base'
+import { MethodNode } from './func'
+
+/**
+ * This node represents an uninitialized package. It only occupies one word, its tag.
+ */
+export class PkgNode extends BaseNode {
+  static create(heap: Heap): PkgNode {
+    const addr = heap.allocate(1)
+    heap.set_tag(addr, TAG.PKG)
+    return new PkgNode(heap, addr)
+  }
+
+  static default(heap: Heap): PkgNode {
+    return PkgNode.create(heap)
+  }
+}
+
+/**
+ * This node represents the `fmt` package. It only occupies one word, its tag.
+ */
+export class FmtPkgNode extends BaseNode {
+  static create(heap: Heap): FmtPkgNode {
+    const addr = heap.allocate(1)
+    heap.set_tag(addr, TAG.FMT_PKG)
+    return new FmtPkgNode(heap, addr)
+  }
+
+  static default(heap: Heap): FmtPkgNode {
+    return FmtPkgNode.create(heap)
+  }
+
+  override select(process: Process, identifier: string): void {
+    process.context.pushOS(
+      MethodNode.create(this.addr, identifier, this.heap).addr,
+    )
+  }
+
+  /** Arguments to builtin methods should be on the OS. Remember to pop the receiver from OS. */
+  override handleMethodCall(
+    process: Process,
+    identifier: string,
+    argCount: number,
+  ) {
+    if (identifier === 'Println') {
+      this.handlePrintln(process, argCount)
+    }
+  }
+
+  handlePrintln(process: Process, argCount: number): void {
+    const argAddresses = []
+    for (let i = 0; i < argCount; i++) {
+      argAddresses.push(process.context.popOS())
+    }
+    for (let i = argCount - 1; i >= 0; i--) {
+      const string = process.heap.get_value(argAddresses[i]).toString()
+      process.print(string)
+      process.print(i > 0 ? ' ' : '\n')
+    }
+    process.context.popOS()
+  }
+
+  override get_children(): number[] {
+    return []
+  }
+
+  override toString(): string {
+    return 'FMT PACKAGE'
+  }
+}

--- a/src/virtual-machine/heap/types/waitGroup.ts
+++ b/src/virtual-machine/heap/types/waitGroup.ts
@@ -51,7 +51,11 @@ export class WaitGroupNode extends BaseNode {
   }
 
   /** Arguments to builtin methods should be on the OS. Remember to pop the receiver from OS. */
-  override handleMethodCall(process: Process, identifier: string) {
+  override handleMethodCall(
+    process: Process,
+    identifier: string,
+    _argCount: number,
+  ) {
     if (identifier === 'Add') {
       this.handleAdd(process)
     } else if (identifier === 'Done') {

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -1,4 +1,3 @@
-// Utility functions to help in parsing.
 {{
   import {
     IntegerLiteralToken,
@@ -49,18 +48,7 @@
     QualifiedIdentifierToken,
   } from './tokens'
 
-  // Checks whether an identifier is valid (not a reserved keyword).
-  function checkIdentifier(identifier) {
-    const reserved_keywords = [
-      'break', 'case', 'chan', 'const', 'continue', 'default',
-      'defer', 'else', 'fallthrough', 'for', 'func', 'go', 'goto',
-      'if', 'import', 'interface', 'map', 'package', 'range', 'return',
-      'select', 'struct', 'switch', 'type', 'var'
-    ]
-    return !reserved_keywords.includes(identifier)
-  }
-
-  // Returns a AST with left to right precedence
+  // Returns an AST with left to right precedence
   function leftPrecTree(rest, right) {
     if (!rest.length) return right
     let last = rest.pop()
@@ -69,28 +57,16 @@
 }}
 
 /*
-The parser will return a tree structure, where every operation has a type,
-some (or none) children, and possibly a value.
-
-For example, a binary multiplication operation looks like this:
-{
-    type: 'binary_operator',
-    name: 'binary_multiplication',
-    children: [...]
-}
-
-An integer literal looks like this:
-{
-    type: 'integer_literal',
-    value: 42
-}
+The result of parsing a source file should be a single SourceFileToken.
+A token may be composed of many other tokens.
+The structure of what each token looks like can be found in each Token class.
 */
 
-// =============== Root ===============
+//* =============== Root ===============
 start = _ @SourceFile _
 
 
-// =============== Whitespace ===============
+//* =============== Whitespace ===============
 // By convention, _ is used to eat up whitespace.
 _ = [ \t\r\n]*
 
@@ -120,7 +96,7 @@ hex_digit     = [0-9a-fA-F]
 //! TODO (P4): Support comments.
 
 //* Identifiers
-identifier = iden:$(letter (letter / unicode_digit)*) &{ return checkIdentifier(iden) }
+identifier = iden:$(letter (letter / unicode_digit)*) &{ return IdentifierToken.isValidIdentifier(iden) }
              { return new IdentifierToken(iden) }
 
 //* Integer Literals

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -9,10 +9,7 @@ import {
   SelectorOperationInstruction,
   SliceOperationInstruction,
 } from '../../compiler/instructions'
-import {
-  CallInstruction,
-  PrintInstruction,
-} from '../../compiler/instructions/funcs'
+import { CallInstruction } from '../../compiler/instructions/funcs'
 import {
   ArrayType,
   BoolType,
@@ -226,7 +223,6 @@ export class BuiltinCallToken extends Token {
     'make',
     'min',
     'max',
-    'Println',
   ] as const
 
   static namesThatTakeType = ['make'] as const
@@ -242,7 +238,6 @@ export class BuiltinCallToken extends Token {
 
   override compile(compiler: Compiler): Type {
     if (this.name === 'make') return this.compileMake(compiler)
-    else if (this.name === 'Println') return this.compilePrintln(compiler)
     else if (this.name === 'len') return this.compileLen(compiler)
     else if (this.name === 'cap') return this.compileCap(compiler)
     else {
@@ -298,16 +293,6 @@ export class BuiltinCallToken extends Token {
     // !TODO Make for slice
     compiler.instructions.push(new LoadChannelInstruction())
     return typeArg
-  }
-
-  private compilePrintln(compiler: Compiler): Type {
-    //! TODO: This should be fmt.Println.
-    for (const arg of this.args) arg.compile(compiler)
-    compiler.instructions.push(
-      new LoadConstantInstruction(this.args.length, new Int64Type()),
-    )
-    compiler.instructions.push(new PrintInstruction())
-    return new NoType()
   }
 
   private throwArgumentLengthError(

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -173,27 +173,31 @@ export class CallToken extends PrimaryExpressionModifierToken {
     const argumentTypes = this.expressions.map((e) => e.compile(compiler))
     compiler.instructions.push(new CallInstruction(this.expressions.length))
 
-    if (argumentTypes.length < operandType.parameters.length) {
-      throw Error(
-        `Not enough arguments in function call\n` +
-          `have (${TypeUtility.arrayToString(argumentTypes)})\n` +
-          `want (${TypeUtility.arrayToString(operandType.parameters)})`,
-      )
-    }
-    if (argumentTypes.length > operandType.parameters.length) {
-      throw Error(
-        `Too many arguments in function call\n` +
-          `have (${TypeUtility.arrayToString(argumentTypes)})\n` +
-          `want (${TypeUtility.arrayToString(operandType.parameters)})`,
-      )
-    }
+    // We only implement variadic functions that accept any number of any type of arguments,
+    // so variadic functions do not require type checking.
+    if (!operandType.variadic) {
+      if (argumentTypes.length < operandType.parameters.length) {
+        throw Error(
+          `Not enough arguments in function call\n` +
+            `have (${TypeUtility.arrayToString(argumentTypes)})\n` +
+            `want (${TypeUtility.arrayToString(operandType.parameters)})`,
+        )
+      }
+      if (argumentTypes.length > operandType.parameters.length) {
+        throw Error(
+          `Too many arguments in function call\n` +
+            `have (${TypeUtility.arrayToString(argumentTypes)})\n` +
+            `want (${TypeUtility.arrayToString(operandType.parameters)})`,
+        )
+      }
 
-    for (let i = 0; i < argumentTypes.length; i++) {
-      if (argumentTypes[i].assignableBy(operandType.parameters[i].type))
-        continue
-      throw Error(
-        `Cannot use ${argumentTypes[i]} as ${operandType.parameters[i]} in argument to function call`,
-      )
+      for (let i = 0; i < argumentTypes.length; i++) {
+        if (argumentTypes[i].assignableBy(operandType.parameters[i].type))
+          continue
+        throw Error(
+          `Cannot use ${argumentTypes[i]} as ${operandType.parameters[i]} in argument to function call`,
+        )
+      }
     }
 
     if (operandType.results.isVoid()) {

--- a/src/virtual-machine/parser/tokens/expressions.ts
+++ b/src/virtual-machine/parser/tokens/expressions.ts
@@ -19,7 +19,6 @@ import {
   ChannelType,
   FunctionType,
   Int64Type,
-  MethodType,
   NoType,
   SliceType,
   StringType,
@@ -165,10 +164,7 @@ export class CallToken extends PrimaryExpressionModifierToken {
   }
 
   override compile(compiler: Compiler, operandType: Type): Type {
-    if (
-      !(operandType instanceof FunctionType) &&
-      !(operandType instanceof MethodType)
-    ) {
+    if (!(operandType instanceof FunctionType)) {
       throw Error(
         `Invalid operation: cannot call non-function (of type ${operandType})`,
       )

--- a/src/virtual-machine/parser/tokens/identifier.ts
+++ b/src/virtual-machine/parser/tokens/identifier.ts
@@ -49,6 +49,11 @@ export class IdentifierToken extends Token {
   }
 }
 
+/**
+ * Note that qualified identifiers in our implementation are only used for types,
+ * as our parser cannot distinguish `package.identifier` from `variable.field`,
+ * hence all values (not types) of the form `x.y` are handled by selector operator instead.
+ */
 export class QualifiedIdentifierToken extends Token {
   constructor(public pkg: string, public identifier: string) {
     super('qualified_identifier')
@@ -59,7 +64,7 @@ export class QualifiedIdentifierToken extends Token {
     if (!(pkg instanceof PackageType)) {
       throw new Error(`${this} is not a type`)
     }
-    return pkg.get(this.identifier)
+    return pkg.select(this.identifier)
   }
 
   override toString(): string {

--- a/src/virtual-machine/parser/tokens/identifier.ts
+++ b/src/virtual-machine/parser/tokens/identifier.ts
@@ -9,6 +9,37 @@ export class IdentifierToken extends Token {
     super('identifier')
   }
 
+  static isValidIdentifier(identifier: string): boolean {
+    const reservedKeywords = [
+      'break',
+      'case',
+      'chan',
+      'const',
+      'continue',
+      'default',
+      'defer',
+      'else',
+      'fallthrough',
+      'for',
+      'func',
+      'go',
+      'goto',
+      'if',
+      'import',
+      'interface',
+      'map',
+      'package',
+      'range',
+      'return',
+      'select',
+      'struct',
+      'switch',
+      'type',
+      'var',
+    ]
+    return !reservedKeywords.includes(identifier)
+  }
+
   override compile(compiler: Compiler): Type {
     const [frame_idx, var_idx] = compiler.context.env.find_var(this.identifier)
     compiler.instructions.push(

--- a/src/virtual-machine/parser/tokens/source_file.ts
+++ b/src/virtual-machine/parser/tokens/source_file.ts
@@ -91,10 +91,7 @@ export class ImportToken extends Token {
   override compile(compiler: Compiler): Type {
     const pkg = this.importPath.getValue()
     if (pkg in builtinPackages) {
-      compiler.type_environment.addType(
-        pkg,
-        builtinPackages[pkg as keyof typeof builtinPackages],
-      )
+      builtinPackages[pkg as keyof typeof builtinPackages](compiler)
     }
     return new NoType()
   }

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -19,7 +19,7 @@ describe('Array Type Checking', () => {
 
   test('Array indexing with non integer type should fail.', () => {
     expect(
-      mainRunner('var a [3]int = [3]int{1, 2, 3}; Println(a[1.2])')
+      mainRunner('var a [3]int = [3]int{1, 2, 3}; fmt.Println(a[1.2])')
         .errorMessage,
     ).toEqual('Invalid argument: Index has type float64 but must be an integer')
   })
@@ -28,29 +28,32 @@ describe('Array Type Checking', () => {
 describe('Array Execution', () => {
   test('Array indexing with valid index works.', () => {
     expect(
-      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n Println(a[2])')
-        .output,
+      mainRunner(
+        'var a [3]string = [3]string{"a", "b", "c"}\n fmt.Println(a[2])',
+      ).output,
     ).toEqual('c\n')
   })
 
   test('Array indexing with negative index fails.', () => {
     expect(
-      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n Println(a[-1])')
-        .errorMessage,
+      mainRunner(
+        'var a [3]string = [3]string{"a", "b", "c"}\n fmt.Println(a[-1])',
+      ).errorMessage,
     ).toEqual('Execution Error: Index out of range [-1] with length 3')
   })
 
   test('Array indexing with out of range index fails.', () => {
     expect(
-      mainRunner('var a [3]string = [3]string{"a", "b", "c"}\n Println(a[3])')
-        .errorMessage,
+      mainRunner(
+        'var a [3]string = [3]string{"a", "b", "c"}\n fmt.Println(a[3])',
+      ).errorMessage,
     ).toEqual('Execution Error: Index out of range [3] with length 3')
   })
 
   test('Nested arrays work.', () => {
     expect(
       mainRunner(
-        'a := [3][3]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}; Println(a[1][2])',
+        'a := [3][3]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}; fmt.Println(a[1][2])',
       ).output,
     ).toEqual('6\n')
   })

--- a/tests/channel.test.ts
+++ b/tests/channel.test.ts
@@ -17,11 +17,11 @@ describe('Channel Tests', () => {
         for i:=0; i < 100; i++ {
           
         }
-        Println("hi")
+        fmt.Println("hi")
         c1 <- 1
       }()
       a := <- c1
-      Println(a)`).output,
+      fmt.Println(a)`).output,
     ).toEqual('hi\n1\n')
   })
 
@@ -32,7 +32,7 @@ describe('Channel Tests', () => {
       go func() {
           c1<- 5
       }()
-      Println(4 + <- c1)`).output,
+      fmt.Println(4 + <- c1)`).output,
     ).toEqual('9\n')
   })
 
@@ -57,15 +57,15 @@ describe('Channel Tests', () => {
          for {
           select {
           case  <- c1:
-           Println("recv!")
+           fmt.Println("recv!")
           case <-c3:
-            Println("stopped")
+            fmt.Println("stopped")
            break
           }
          }
         }()
          for i:=0; i < 5; i++{}
-         Println("done")
+         fmt.Println("done")
          c2 <- "stop"`)
       .output?.trim()
       .split('\n')
@@ -96,9 +96,9 @@ describe('Channel Tests', () => {
          for i := 0; i < n; i++ {
           select {
           case c1 <- 1:
-           Println("Write 1 1")
+           fmt.Println("Write 1 1")
           case <-c1:
-           Println("Read 1 2")
+           fmt.Println("Read 1 2")
           }
          }
         }()
@@ -107,9 +107,9 @@ describe('Channel Tests', () => {
          for i := 0; i < n; i++ {
           select {
           case c1 <- 2:
-           Println("Write 2 2")
+           fmt.Println("Write 2 2")
           case <-c1:
-           Println("Read 2 1")
+           fmt.Println("Read 2 1")
           }
          }
         }()`)
@@ -140,11 +140,11 @@ describe('Channel Tests', () => {
       }
       go func(){
         c1<- 1
-        Println("done2")
+        fmt.Println("done2")
       }()
       for i:=0;i < 100;i++ {
       }
-      Println("done1")
+      fmt.Println("done1")
       <-c1`).output,
     ).toEqual('done1\ndone2\n')
   })

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -15,7 +15,7 @@ describe('Concurrency Check', () => {
           a+=1
           for j := 0; j < 100 ; j++ {
           }
-          Println(a)`).output,
+          fmt.Println(a)`).output,
     ).toEqual('6\n')
   })
   test('Race Cond', () => {
@@ -32,7 +32,7 @@ describe('Concurrency Check', () => {
       }
         for j := 0; j < 1000 ; j++ {
         }
-      Println(a)`).output || '100',
+      fmt.Println(a)`).output || '100',
       ),
     ).toBeLessThan(500)
   })

--- a/tests/control.test.ts
+++ b/tests/control.test.ts
@@ -13,7 +13,7 @@ describe('Variable Declaration Tests', () => {
         } else {\
           a += -i\
         }\
-        Println(a)',
+        fmt.Println(a)',
       ).output,
     ).toEqual('1334\n')
   })
@@ -26,7 +26,7 @@ describe('Variable Declaration Tests', () => {
           i := 3\
           a += i\
         }\
-        Println(a)',
+        fmt.Println(a)',
       ).output,
     ).toEqual('25\n')
   })
@@ -42,7 +42,7 @@ describe('Variable Declaration Tests', () => {
           i := 3\
           a += i\
         }\
-        Println(a)',
+        fmt.Println(a)',
       ).output,
     ).toEqual('19\n')
   })
@@ -58,7 +58,7 @@ describe('Variable Declaration Tests', () => {
           i := 3\
           a += i\
         }\
-        Println(a)',
+        fmt.Println(a)',
       ).output,
     ).toEqual('12\n')
   })

--- a/tests/declaration.test.ts
+++ b/tests/declaration.test.ts
@@ -9,7 +9,7 @@ describe('Variable Declaration Tests', () => {
         'var a int = 3;\
         const b int = 5;\
         const c int = b;\
-        Println(a+b+c)',
+        fmt.Println(a+b+c)',
       ).output,
     ).toEqual('13\n')
   })
@@ -19,7 +19,7 @@ describe('Variable Declaration Tests', () => {
       mainRunner(
         'a := "hi";\
         b := "hi2";\
-        Println(a + b)',
+        fmt.Println(a + b)',
       ).output,
     ).toEqual('hihi2\n')
   })
@@ -27,10 +27,10 @@ describe('Variable Declaration Tests', () => {
   test('Boolean constants true and false are predeclared', () => {
     const code = `
     if false {
-      Println("false")
+      fmt.Println("false")
     }
     if true {
-      Println("true")
+      fmt.Println("true")
     }
     `
     expect(mainRunner(code).output).toEqual('true\n')
@@ -41,10 +41,10 @@ describe('Variable Declaration Tests', () => {
     true := false
     false := true
     if false {
-      Println("false")
+      fmt.Println("false")
     }
     if true {
-      Println("true")
+      fmt.Println("true")
     }
     `
     expect(mainRunner(code).output).toEqual('')

--- a/tests/defer.test.ts
+++ b/tests/defer.test.ts
@@ -18,9 +18,9 @@ describe('Defer Type Checking', () => {
 describe('Defer Execution', () => {
   test('Defer runs in order', () => {
     const code = `
-    defer func(){ Println("!!!") }()
-    defer func(){ Println("world") }()
-    Println("hello")
+    defer func(){ fmt.Println("!!!") }()
+    defer func(){ fmt.Println("world") }()
+    fmt.Println("hello")
     `
     expect(mainRunner(code).output).toEqual('hello\nworld\n!!!\n')
   })
@@ -28,6 +28,7 @@ describe('Defer Execution', () => {
   test('Defer with wait groups work', () => {
     const code = `
     package main
+    import "fmt"
     import "sync"
     func main() {
       count := 0
@@ -40,7 +41,7 @@ describe('Defer Execution', () => {
         }()
       }
       wg.Wait()
-      Println(count)
+      fmt.Println(count)
     }
     `
     expect(runCode(code, 2048).output).toEqual('1000\n')

--- a/tests/environment.test.ts
+++ b/tests/environment.test.ts
@@ -10,7 +10,7 @@ describe('Basic Environment Tests', () => {
           b:= a + 3;\
           c := a + b;\
           c *= a;\
-          Println(a + b + c)',
+          fmt.Println(a + b + c)',
       ).output,
     ).toEqual('36\n')
   })
@@ -22,7 +22,7 @@ describe('Basic Environment Tests', () => {
           var a int = 1;\
           a = 2;\
         };\
-        Println(a)',
+        fmt.Println(a)',
       ).output,
     ).toEqual('3\n')
   })

--- a/tests/expression.test.ts
+++ b/tests/expression.test.ts
@@ -4,14 +4,16 @@ import { mainRunner } from './utility'
 
 describe('Basic Expression Tests', () => {
   test('Basic Arithmetic 1', () => {
-    expect(mainRunner('Println(5 * -1 + 3 * 4 / 2 + 3)').output).toEqual('4\n')
+    expect(mainRunner('fmt.Println(5 * -1 + 3 * 4 / 2 + 3)').output).toEqual(
+      '4\n',
+    )
   })
   test('Basic Arithmetic 2', () => {
-    expect(mainRunner('Println((4+3)*5%(5+3)+2)').output).toEqual('5\n')
+    expect(mainRunner('fmt.Println((4+3)*5%(5+3)+2)').output).toEqual('5\n')
   })
   test('Boolean Expression', () => {
     expect(
-      mainRunner('Println((2+1 < 3) || (7 == 9%5 + 15/5))').output,
+      mainRunner('fmt.Println((2+1 < 3) || (7 == 9%5 + 15/5))').output,
     ).toEqual('true\n')
   })
 })

--- a/tests/fmt.test.ts
+++ b/tests/fmt.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest'
+
+import { mainRunner } from './utility'
+
+describe('fmt Type Checking', () => {
+  test('Selector on fmt should fail unless it is Println.', () => {
+    const code = `
+    fmt.nonexistent("hi")
+    `
+    expect(mainRunner(code).errorMessage).toEqual('undefined: fmt.nonexistent')
+  })
+})
+
+describe('fmt Execution', () => {
+  test('Println works', () => {
+    const code = `
+    Println("Hello", "world", true, false)
+    Println(1, 2, 3, 4)
+    `
+    expect(mainRunner(code).output).toEqual('Hello world true false\n1 2 3 4\n')
+  })
+})

--- a/tests/fmt.test.ts
+++ b/tests/fmt.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { mainRunner } from './utility'
 
 describe('fmt Type Checking', () => {
-  test('Selector on fmt should fail unless it is Println.', () => {
+  test('Selector on fmt should fail unless it is fmt.Println.', () => {
     const code = `
     fmt.nonexistent("hi")
     `
@@ -12,10 +12,10 @@ describe('fmt Type Checking', () => {
 })
 
 describe('fmt Execution', () => {
-  test('Println works', () => {
+  test('fmt.Println works', () => {
     const code = `
-    Println("Hello", "world", true, false)
-    Println(1, 2, 3, 4)
+    fmt.Println("Hello", "world", true, false)
+    fmt.Println(1, 2, 3, 4)
     `
     expect(mainRunner(code).output).toEqual('Hello world true false\n1 2 3 4\n')
   })

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -75,7 +75,7 @@ describe('Function Execution tests', () => {
         'f := func(x int, y int) int{\
         return x + y\
       }\
-      Println(1 + f(1, 2))',
+      fmt.Println(1 + f(1, 2))',
       ).output,
     ).toEqual('4\n')
   })
@@ -84,6 +84,7 @@ describe('Function Execution tests', () => {
     expect(
       runCode(
         `package main
+        import "fmt"
 
         var a int = 1
         
@@ -95,7 +96,7 @@ describe('Function Execution tests', () => {
           f := func(x, y int) int {
             return x + y + 100
           }
-          Println(f(1, 2))
+          fmt.Println(f(1, 2))
         }`,
         2048,
       ).output,
@@ -106,6 +107,7 @@ describe('Function Execution tests', () => {
     expect(
       runCode(
         `package main
+        import "fmt"
         func main() {
           f := func(x, y int) int {
             return x + y
@@ -115,7 +117,7 @@ describe('Function Execution tests', () => {
               return x + y + i
             }
           }
-          Println(f(1, 2))
+          fmt.Println(f(1, 2))
         }`,
         2048,
       ).output,
@@ -125,7 +127,8 @@ describe('Function Execution tests', () => {
   test('Function assignment in loop and if', () => {
     expect(
       runCode(
-        `package main
+        `package mai
+        import "fmt"
         func main() {
           f := func(x, y int) int {
             return x + y
@@ -137,7 +140,7 @@ describe('Function Execution tests', () => {
               }
             }
           }
-          Println(f(1, 2))
+          fmt.Println(f(1, 2))
         }`,
         2048,
       ).output,
@@ -149,6 +152,8 @@ describe('Function Execution tests', () => {
       runCode(
         `package main
 
+      import "fmt"
+
       func f(x int) int {
         if x == 0 {
           return 0
@@ -157,7 +162,7 @@ describe('Function Execution tests', () => {
       }
       
       func main() {
-        Println(f(10))
+        fmt.Println(f(10))
       }`,
         2048,
       ).output,
@@ -165,9 +170,9 @@ describe('Function Execution tests', () => {
   })
 
   test('Calling a function twice.', () => {
-    expect(mainRunner('f := func(){ Println(1) }; f(); f()').output).toEqual(
-      '1\n1\n',
-    )
+    expect(
+      mainRunner('f := func(){ fmt.Println(1) }; f(); f()').output,
+    ).toEqual('1\n1\n')
   })
 
   test('Closures', () => {
@@ -189,12 +194,12 @@ describe('Function Execution tests', () => {
         func main() {
           f := getAreaFunc()
           f2 := getAreaFunc()
-          Println(f(3, 2))
-          Println(f(1, 1))
-          Println(f(1, 1))
-          Println(f2(1, 1))
-          Println(f2(2, 3))
-          Println(f2(1, 1))
+          fmt.Println(f(3, 2))
+          fmt.Println(f(1, 1))
+          fmt.Println(f(1, 1))
+          fmt.Println(f2(1, 1))
+          fmt.Println(f2(2, 3))
+          fmt.Println(f2(1, 1))
         }
     `,
         2048,

--- a/tests/slice.test.ts
+++ b/tests/slice.test.ts
@@ -11,13 +11,14 @@ describe('Slice Type Checking', () => {
 
   test('Slice indexing with non integer type should fail.', () => {
     expect(
-      mainRunner('var a []int = []int{1, 2, 3}; Println(a[1.2])').errorMessage,
+      mainRunner('var a []int = []int{1, 2, 3}; fmt.Println(a[1.2])')
+        .errorMessage,
     ).toEqual('Invalid argument: Index has type float64 but must be an integer')
   })
 
   test('Slice len with too little arguments fails', () => {
     expect(
-      mainRunner('a := []int{1, 2, 3, 4}; Println(len())').errorMessage,
+      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len())').errorMessage,
     ).toEqual(
       'Invalid operation: not enough arguments for len (expected 1, found 0)',
     )
@@ -25,7 +26,7 @@ describe('Slice Type Checking', () => {
 
   test('Slice len with too many arguments fails', () => {
     expect(
-      mainRunner('a := []int{1, 2, 3, 4}; Println(len(a, a))').errorMessage,
+      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len(a, a))').errorMessage,
     ).toEqual(
       'Invalid operation: too many arguments for len (expected 1, found 2)',
     )
@@ -33,7 +34,7 @@ describe('Slice Type Checking', () => {
 
   test('Slice len with wrong type', () => {
     expect(
-      mainRunner('a := []int{1, 2, 3, 4}; Println(len(1))').errorMessage,
+      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len(1))').errorMessage,
     ).toEqual('Invalid argument: (int64) for len')
   })
 
@@ -47,21 +48,22 @@ describe('Slice Type Checking', () => {
 describe('Slice Execution', () => {
   test('Slice indexing with valid index works.', () => {
     expect(
-      mainRunner('var a []string = []string{"a", "b", "c"}\n Println(a[2])')
+      mainRunner('var a []string = []string{"a", "b", "c"}\n fmt.Println(a[2])')
         .output,
     ).toEqual('c\n')
   })
 
   test('Slice indexing with negative index fails.', () => {
     expect(
-      mainRunner('var a []string = []string{"a", "b", "c"}\n Println(a[-1])')
-        .errorMessage,
+      mainRunner(
+        'var a []string = []string{"a", "b", "c"}\n fmt.Println(a[-1])',
+      ).errorMessage,
     ).toEqual('Execution Error: Index out of range [-1] with length 3')
   })
 
   test('Slice indexing with out of range index fails.', () => {
     expect(
-      mainRunner('var a []string = []string{"a", "b", "c"}\n Println(a[3])')
+      mainRunner('var a []string = []string{"a", "b", "c"}\n fmt.Println(a[3])')
         .errorMessage,
     ).toEqual('Execution Error: Index out of range [3] with length 3')
   })
@@ -69,20 +71,20 @@ describe('Slice Execution', () => {
   test('Nested slices work.', () => {
     expect(
       mainRunner(
-        'a := [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}; Println(a[1][2])',
+        'a := [][]int{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}; fmt.Println(a[1][2])',
       ).output,
     ).toEqual('6\n')
   })
 
   test('Slice len works.', () => {
     expect(
-      mainRunner('a := [][]int{{1}, {2}, {3}}; Println(len(a))').output,
+      mainRunner('a := [][]int{{1}, {2}, {3}}; fmt.Println(len(a))').output,
     ).toEqual('3\n')
   })
 
   test('Slice capacity works.', () => {
     expect(
-      mainRunner('a := [][]int{{1}, {2}, {3}}; Println(cap(a))').output,
+      mainRunner('a := [][]int{{1}, {2}, {3}}; fmt.Println(cap(a))').output,
     ).toEqual('3\n')
   })
 
@@ -90,13 +92,13 @@ describe('Slice Execution', () => {
     expect(
       mainRunner(`a := [4]int{0, 1, 2, 3}
       b := a[:]
-      Println(b)
+      fmt.Println(b)
       b = b[2:]
-      Println(b)
+      fmt.Println(b)
       c := b[1:]
-      Println(c)
+      fmt.Println(c)
       c = c[1:]
-      Println(c)`).output,
+      fmt.Println(c)`).output,
     ).toEqual('[0 1 2 3]\n[2 3]\n[3]\n[]\n')
   })
 

--- a/tests/utility.ts
+++ b/tests/utility.ts
@@ -2,5 +2,12 @@ import { runCode } from '../src/virtual-machine'
 
 /** Runs the code in a main function */
 export const mainRunner = (code: string) => {
-  return runCode(`package main;\nfunc main() {\n${code}\n}`, 2048)
+  const packagedCode = `
+  package main
+  import "fmt"
+  func main() {
+    ${code}
+  }
+  `
+  return runCode(packagedCode, 2048)
 }

--- a/tests/waitGroup.test.ts
+++ b/tests/waitGroup.test.ts
@@ -76,6 +76,7 @@ describe('Wait Group Execution', () => {
   test('Waiting works.', () => {
     const code = `
     package main
+    import "fmt"
     import "sync"
     func main() {
       count := 0
@@ -88,7 +89,7 @@ describe('Wait Group Execution', () => {
         }()
       }
       wg.Wait()
-      Println(count)
+      fmt.Println(count)
     }
     `
     expect(runCode(code, 2048).output).toEqual('1000\n')


### PR DESCRIPTION
This PR adds the `fmt` package. It allows users to `import "fmt"` and then use `fmt.Println()`. The old builtin `Println` function has been removed.

Implementation:
- Builtin packages are defined in `typing/package.ts`. Each package definition is responsible for its own compilation, such as adding itself as a variable to the type environment and to the frame.
- A package is stored on the heap at runtime as a single node that implements the selector operation.
- Currently there is only a `fmt` package, as the `sync` package only contains the type `sync.WaitGroup`, which is not needed during runtime at all, so there is no need to create a `sync` package node.

Note on qualified identifiers:
- Currently all types of the form `package.identifier` are parsed as QualifiedIdentifierToken. This is due to us previously strictly following the Golang specs, which distinguishes such qualified identifiers from the selector operator `variable.field`.
- It may be possible to completely remove QualifiedIdentifierToken in a future PR, as our treatment of it is somewhat the same as selector operator.