### PR TITLE
Feat/source mapping

### DIFF
--- a/src/frontend/components/CodeIDE/CodeIDE.tsx
+++ b/src/frontend/components/CodeIDE/CodeIDE.tsx
@@ -4,12 +4,12 @@ import { Prec } from '@codemirror/state'
 import { keymap } from '@codemirror/view'
 import { zebraStripes } from '@uiw/codemirror-extensions-zebra-stripes'
 import { githubDark, githubLight } from '@uiw/codemirror-theme-github'
-import CodeMirror from '@uiw/react-codemirror'
+import CodeMirror, { EditorSelection } from '@uiw/react-codemirror'
 
 interface codeIDEProps {
   code: string
   setCode: (code: string) => void
-  lineHighlight?: number
+  lineHighlight?: (number | number[])[]
   run: () => void
 }
 
@@ -25,7 +25,7 @@ export const CodeIDE = (props: codeIDEProps) => {
       width="100%"
       extensions={[
         zebraStripes({
-          lineNumber: [lineHighlight || 0],
+          lineNumber: lineHighlight,
           lightColor: '#aca2ff33',
           darkColor: '#aca2ff40',
         }),
@@ -44,6 +44,7 @@ export const CodeIDE = (props: codeIDEProps) => {
       ]}
       onChange={setCode}
       theme={useColorModeValue(githubLight, githubDark)}
+      selection={EditorSelection.cursor(5)}
     />
   )
 }

--- a/src/frontend/pages/Main.tsx
+++ b/src/frontend/pages/Main.tsx
@@ -64,9 +64,12 @@ export const Main = () => {
   }
 
   const toast = useToast()
-  const makeToast = (msg: string | undefined) => {
+  const makeToast = (
+    msg: string | undefined,
+    title = 'An Error Has Occured!',
+  ) => {
     toast({
-      title: 'An Error Has Occured',
+      title,
       description: msg,
       status: 'error',
       duration: 2000,
@@ -127,8 +130,13 @@ export const Main = () => {
       visualData,
     } = runCode(code, heapsize, visualMode)
     if (error) {
+      const errorTitle = {
+        parse: 'Syntax Error',
+        compile: 'Compile Error',
+        runtime: 'Runtime Error',
+      }[error.type]
       setLoading(false)
-      makeToast(error.message)
+      makeToast(error.message, errorTitle)
 
       if (error.type === 'compile') {
         // Highlight compile error in source code.

--- a/src/frontend/pages/Main.tsx
+++ b/src/frontend/pages/Main.tsx
@@ -114,13 +114,13 @@ export const Main = () => {
     // Retrieve instructions from endpoint
     setOutput('Running your code...')
     const {
-      errorMessage,
+      error,
       output: newOutput,
       visualData,
     } = runCode(code, heapsize, visualMode)
-    if (errorMessage) {
+    if (error) {
       setLoading(false)
-      makeToast(errorMessage)
+      makeToast(error.message)
     }
 
     // Set instructions and update components to start playing mode

--- a/src/frontend/pages/Main.tsx
+++ b/src/frontend/pages/Main.tsx
@@ -11,6 +11,7 @@ import {
 import Cookies from 'js-cookie'
 
 import { runCode } from '../../virtual-machine'
+import { CompileError } from '../../virtual-machine/compiler'
 import {
   CodeIDE,
   CodeIDEButtons,
@@ -59,6 +60,7 @@ export const Main = () => {
   const modifyCode = (code: string) => {
     Cookies.set(COOKIE_NAME, btoa(code))
     setCode(code)
+    resetErrors()
   }
 
   const toast = useToast()
@@ -103,6 +105,12 @@ export const Main = () => {
     }
   }
 
+  const [lineHighlight, setLineHighlight] = useState<(number | number[])[]>([0])
+
+  const resetErrors = () => {
+    setLineHighlight([0])
+  }
+
   const startRunning = async () => {
     // Start playing
     setLoading(true)
@@ -121,6 +129,21 @@ export const Main = () => {
     if (error) {
       setLoading(false)
       makeToast(error.message)
+
+      if (error.type === 'compile') {
+        // Highlight compile error in source code.
+        const details = error.details as CompileError
+        const startLine = details.sourceLocation.start.line
+        let endLine = details.sourceLocation.end.line
+        if (details.sourceLocation.end.column === 1) {
+          // When parsing, the token's end location may spill into the next line.
+          // If so, then we should ignore the last line.
+          endLine--
+        }
+        setLineHighlight([[startLine, endLine]])
+      }
+    } else {
+      resetErrors()
     }
 
     // Set instructions and update components to start playing mode
@@ -166,7 +189,7 @@ export const Main = () => {
           <CodeIDE
             code={code}
             setCode={modifyCode}
-            lineHighlight={0}
+            lineHighlight={lineHighlight}
             run={startRunning}
           />
         </Box>

--- a/src/virtual-machine/compiler/index.ts
+++ b/src/virtual-machine/compiler/index.ts
@@ -1,8 +1,14 @@
-import { Token } from '../parser/tokens'
+import { Token, TokenLocation } from '../parser/tokens'
 
 import { TypeEnvironment } from './typing/type_environment'
 import { CompileContext } from './environment'
 import { DoneInstruction, Instruction } from './instructions'
+
+export class CompileError extends Error {
+  constructor(message: string, public sourceLocation: TokenLocation) {
+    super(message)
+  }
+}
 
 export class Compiler {
   instructions: Instruction[] = []
@@ -10,8 +16,12 @@ export class Compiler {
   type_environment = new TypeEnvironment()
 
   compile_program(token: Token) {
-    token.compileUnchecked(this)
+    token.compile(this)
     this.instructions.push(new DoneInstruction())
+  }
+
+  throwCompileError(message: string, sourceLocation: TokenLocation): never {
+    throw new CompileError(message, sourceLocation)
   }
 }
 

--- a/src/virtual-machine/compiler/index.ts
+++ b/src/virtual-machine/compiler/index.ts
@@ -10,7 +10,7 @@ export class Compiler {
   type_environment = new TypeEnvironment()
 
   compile_program(token: Token) {
-    token.compile(this)
+    token.compileUnchecked(this)
     this.instructions.push(new DoneInstruction())
   }
 }

--- a/src/virtual-machine/index.ts
+++ b/src/virtual-machine/index.ts
@@ -31,11 +31,12 @@ const runCode = (
     tokens = parser.parse(source_code) as SourceFileToken
     console.log(tokens)
   } catch (err) {
+    const message = (err as Error).message
     return {
       instructions: [],
       output: 'Syntax Error!',
       error: {
-        message: `${err as string}`,
+        message,
         type: 'parse',
         details: err as string,
       },
@@ -49,11 +50,12 @@ const runCode = (
     instructions = compile_tokens(tokens)
     console.log(instructions)
   } catch (err) {
+    const message = (err as CompileError).message
     return {
       instructions: [],
       output: 'Compilation Error!',
       error: {
-        message: `Compilation Error:\n${err as CompileError}`,
+        message,
         type: 'compile',
         details: err as CompileError,
       },

--- a/src/virtual-machine/index.ts
+++ b/src/virtual-machine/index.ts
@@ -1,7 +1,8 @@
+import { Instruction } from './compiler/instructions'
 import { StateInfo } from './executor/debugger'
 import parser from './parser/parser'
 import { SourceFileToken } from './parser/tokens'
-import { compile_tokens } from './compiler'
+import { compile_tokens, CompileError } from './compiler'
 import { execute_instructions } from './executor'
 
 interface InstructionData {
@@ -11,7 +12,11 @@ interface InstructionData {
 interface ProgramData {
   output?: string
   instructions: InstructionData[]
-  errorMessage?: string
+  error?: {
+    message: string
+    type: 'parse' | 'compile' | 'runtime'
+    details?: Error | string
+  }
   visualData: StateInfo[]
 }
 
@@ -20,30 +25,63 @@ const runCode = (
   heapsize: number,
   visualisation = true,
 ): ProgramData => {
-  let errorMessage = ''
+  // Parsing.
+  let tokens: SourceFileToken
   try {
-    const tokens = parser.parse(source_code) as SourceFileToken
+    tokens = parser.parse(source_code) as SourceFileToken
     console.log(tokens)
-    const instructions = compile_tokens(tokens)
-    console.log(instructions)
-    const result = execute_instructions(instructions, heapsize, visualisation)
-    // console.log(result)
-    // console.log(result.visual_data)
+  } catch (err) {
     return {
       instructions: [],
-      output: result.stdout,
-      visualData: result.visual_data,
-      errorMessage: result.errorMessage,
+      output: 'Syntax Error!',
+      error: {
+        message: `${err as string}`,
+        type: 'parse',
+        details: err as string,
+      },
+      visualData: [],
     }
-  } catch (err) {
-    console.warn(err)
-    if (err instanceof Error) errorMessage = err.message
   }
+
+  // Compilation.
+  let instructions: Instruction[] = []
+  try {
+    instructions = compile_tokens(tokens)
+    console.log(instructions)
+  } catch (err) {
+    return {
+      instructions: [],
+      output: 'Compilation Error!',
+      error: {
+        message: `Compilation Error:\n${err as CompileError}`,
+        type: 'compile',
+        details: err as CompileError,
+      },
+      visualData: [],
+    }
+  }
+
+  // Execution.
+  const result = execute_instructions(instructions, heapsize, visualisation)
+  if (result.errorMessage) {
+    console.warn(result.errorMessage)
+    return {
+      instructions: [],
+      output: 'Runtime Error!',
+      error: {
+        message: result.errorMessage,
+        type: 'runtime',
+        details: result.errorMessage,
+      },
+      visualData: [],
+    }
+  }
+
   return {
     instructions: [],
-    output: 'An Error Occurred!',
-    errorMessage: errorMessage,
-    visualData: [],
+    output: result.stdout,
+    visualData: result.visual_data,
+    error: undefined,
   }
 }
 

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -97,13 +97,13 @@ hex_digit     = [0-9a-fA-F]
 
 //* Identifiers
 identifier = iden:$(letter (letter / unicode_digit)*) &{ return IdentifierToken.isValidIdentifier(iden) }
-             { return new IdentifierToken(iden) }
+             { return new IdentifierToken(location(), iden) }
 
 //* Integer Literals
-int_lit = number:binary_lit  { return IntegerLiteralToken.fromSource(number, 2) } /
-          number:octal_lit   { return IntegerLiteralToken.fromSource(number, 8) } /
-          number:decimal_lit { return IntegerLiteralToken.fromSource(number, 10) } /
-          number:hex_lit     { return IntegerLiteralToken.fromSource(number, 16) } 
+int_lit = number:binary_lit  { return IntegerLiteralToken.fromSource(location(), number, 2) } /
+          number:octal_lit   { return IntegerLiteralToken.fromSource(location(), number, 8) } /
+          number:decimal_lit { return IntegerLiteralToken.fromSource(location(), number, 10) } /
+          number:hex_lit     { return IntegerLiteralToken.fromSource(location(), number, 16) } 
 binary_lit  = "0" "b" "_"? $binary_digits
 octal_lit   = "0" [oO]? "_"? $octal_digits
 decimal_lit = $([1-9] "_"? decimal_digits?) /
@@ -117,7 +117,7 @@ hex_digits     = hex_digit     ("_"? hex_digit)*
 
 //* Floating-point Literals
 //! TODO (P5): Support hexadecimal floating points.
-float_lit = number:$decimal_float_lit { return FloatLiteralToken.fromSource(number); }
+float_lit = number:$decimal_float_lit { return FloatLiteralToken.fromSource(location(), number); }
 
 decimal_float_lit = decimal_digits "." decimal_digits? decimal_exponent? /
                     decimal_digits decimal_exponent /
@@ -129,8 +129,8 @@ decimal_exponent  = [eE] ("+" / "-")? decimal_digits
 
 //* String Literals
 string_lit             = raw_string_lit / interpreted_string_lit
-raw_string_lit         = "`" str:$[^`]* "`" { return StringLiteralToken.fromSourceRaw(str) }
-interpreted_string_lit = '"' str:$[^\n"]* '"' { return StringLiteralToken.fromSourceInterpreted(str) }
+raw_string_lit         = "`" str:$[^`]* "`" { return StringLiteralToken.fromSourceRaw(location(), str) }
+interpreted_string_lit = '"' str:$[^\n"]* '"' { return StringLiteralToken.fromSourceInterpreted(location(), str) }
 //! TODO (P3): Interpreted string literals should interpret rune literals.
 
 
@@ -142,19 +142,19 @@ interpreted_string_lit = '"' str:$[^\n"]* '"' { return StringLiteralToken.fromSo
 Type     = @TypeName / TypeLit / "(" _ Type _ ")"
 //! TODO (P1): Support qualified identifiers for TypeName.
 TypeName = iden:identifier &{ return PrimitiveTypeToken.isPrimitive(iden.identifier) }
-           { return new PrimitiveTypeToken(iden.identifier) }
+           { return new PrimitiveTypeToken(location(), iden.identifier) }
          / @QualifiedIdent
 TypeLit  = ArrayType / StructType / PointerType / FunctionType / InterfaceType / SliceType / MapType / ChannelType
 
 //* Array Types
-ArrayType   = "[" _ length:ArrayLength _ "]" element:ElementType { return new ArrayTypeToken(element, length) }
+ArrayType   = "[" _ length:ArrayLength _ "]" element:ElementType { return new ArrayTypeToken(location(), element, length) }
 // Note: ArrayLength is actually an Expression in Golang specification, but we didn't want to implement
 // expression evaluation INSIDE the compiler. Hence, we chose to only allow int_lit.
 ArrayLength = int_lit
 ElementType = Type
 
 //* Slice Types
-SliceType = "[" "]" element:ElementType { return new SliceTypeToken(element) }
+SliceType = "[" "]" element:ElementType { return new SliceTypeToken(location(), element) }
 
 //* Struct Types
 StructType    = "struct" _ "{" _ (_ FieldDecl _ ";"?)* _ "}"
@@ -168,7 +168,7 @@ BaseType = Type
 
 //* Function Types
 FunctionType  = "func" _ @Signature
-Signature     = params:Parameters _ result:Result? { return new FunctionTypeToken(params, result) }
+Signature     = params:Parameters _ result:Result? { return new FunctionTypeToken(location(), params, result) }
 Result        = @Parameters / type:Type { return [{ type }] }
 // Parameters is an array of { identifier?: string, type: TypeToken }.
 Parameters    = "(" _ parameters:ParameterList? _ ","? _ ")" { return parameters ?? [] }
@@ -190,20 +190,20 @@ TypeTerm       = Type / UnderlyingType
 UnderlyingType = "~" Type
 
 //* Map Types
-MapType = "map" _ "[" _ key:KeyType _ "]" _ element:ElementType { return new MapTypeToken(key, element) }
+MapType = "map" _ "[" _ key:KeyType _ "]" _ element:ElementType { return new MapTypeToken(location(), key, element) }
 KeyType = Type
 
 //* Channel Types
-ChannelType = "chan" _ "<-" _ element:ElementType { return new ChannelTypeToken(element, false, true) }
-              / "<-" _ "chan" _ element:ElementType { return new ChannelTypeToken(element, true, false) }
-              / "chan" _ element:ElementType { return new ChannelTypeToken(element, true, true) }
+ChannelType = "chan" _ "<-" _ element:ElementType { return new ChannelTypeToken(location(), element, false, true) }
+              / "<-" _ "chan" _ element:ElementType { return new ChannelTypeToken(location(), element, true, false) }
+              / "chan" _ element:ElementType { return new ChannelTypeToken(location(), element, true, true) }
 
 
 
 
 
 //* =============== Blocks ===============
-Block = "{" _ statements:StatementList _ "}" { return new BlockToken(statements) }
+Block = "{" _ statements:StatementList _ "}" { return new BlockToken(location(), statements) }
 StatementList = (_ @Statement _ ";"?)*
 
 
@@ -223,7 +223,7 @@ ConstSpec      = identifiers:IdentifierList _ rest:(
                     varType:Type? _ "=" _ expressions:ExpressionList
                     { return { varType, expressions } }
                  )
-                 { return new ConstantDeclarationToken(identifiers, rest.expressions, rest.varType) }
+                 { return new ConstantDeclarationToken(location(), identifiers, rest.expressions, rest.varType) }
 
 IdentifierList = head:identifier tail:(_ "," _ @identifier _)* { return [head, ...tail] }
 ExpressionList = head:Expression tail:(_ "," _ @Expression _)* { return [head, ...tail] }
@@ -248,16 +248,16 @@ VarSpec = identifiers:IdentifierList _ rest:(
             _ "=" _ expressions:ExpressionList
             { return {varType: undefined, expressions} }
           )
-          { return new VariableDeclarationToken(identifiers, rest.varType, rest.expressions) }
+          { return new VariableDeclarationToken(location(), identifiers, rest.varType, rest.expressions) }
 
 //* Short Variable Declarations
 ShortVarDecl = identifiers:IdentifierList _ ":=" _ expressions:ExpressionList
-               { return new ShortVariableDeclarationToken(identifiers, expressions) }
+               { return new ShortVariableDeclarationToken(location(), identifiers, expressions) }
 
 //* Function Declarations
 // Note: TypeParameters? is omitted from FunctionDecl as we do not support generics.
 FunctionDecl = "func" _ name:FunctionName _ signature:Signature _ body:Block?
-               { return new FunctionDeclarationToken(name, new FunctionLiteralToken(signature, body)) }
+               { return new FunctionDeclarationToken(location(), name, new FunctionLiteralToken(location(), signature, body)) }
 FunctionName = identifier
 FunctionBody = Block
 
@@ -280,42 +280,42 @@ BasicLit    = float_lit / int_lit / string_lit
 OperandName = identifier / QualifiedIdent
 
 //* Qualified Identifiers
-QualifiedIdent = pkg:PackageName "." iden:identifier { return new QualifiedIdentifierToken(pkg.identifier, iden.identifier) }
+QualifiedIdent = pkg:PackageName "." iden:identifier { return new QualifiedIdentifierToken(location(), pkg.identifier, iden.identifier) }
 
 //* Composite Literals
-CompositeLit = type:ArrayType _ value:LiteralValue { return new ArrayLiteralToken(type, value) }
-             / type:SliceType _ value:LiteralValue { return new SliceLiteralToken(type, value) }
-LiteralValue = "{" elements:(@ElementList _ ","? _)? "}" { return new LiteralValueToken(elements ?? []) }
+CompositeLit = type:ArrayType _ value:LiteralValue { return new ArrayLiteralToken(location(), type, value) }
+             / type:SliceType _ value:LiteralValue { return new SliceLiteralToken(location(), type, value) }
+LiteralValue = "{" elements:(@ElementList _ ","? _)? "}" { return new LiteralValueToken(location(), elements ?? []) }
 ElementList  = head:KeyedElement rest:(_ "," _ @KeyedElement)* { return [head, ...rest] }
 // Ironically, KeyedElement will not support having a key for our implementation.
 KeyedElement = Element
 Element      = Expression / LiteralValue
 
 //* Function Literals
-FunctionLit = "func" _ signature:Signature _ body:FunctionBody { return new FunctionLiteralToken(signature, body) }
+FunctionLit = "func" _ signature:Signature _ body:FunctionBody { return new FunctionLiteralToken(location(), signature, body) }
 
 //* Primary Expressions
 //! TODO (P5): MethodExpr and Conversion are not supported.
-PrimaryExpr     = operand:(@BuiltinCall / @Operand) _ rest:PrimaryExprModifier* { return new PrimaryExpressionToken(operand, rest) }
+PrimaryExpr     = operand:(@BuiltinCall / @Operand) _ rest:PrimaryExprModifier* { return new PrimaryExpressionToken(location(), operand, rest) }
 // This PrimaryExprTerm is added to fix left recursion.
 PrimaryExprModifier = Selector / Index / Slice / TypeAssertion / Arguments
-Selector      = "." identifier:identifier { return new SelectorToken(identifier.identifier) }
-Index         = "[" _ expr:Expression (_ ",")? _ "]" { return new IndexToken(expr) }
+Selector      = "." identifier:identifier { return new SelectorToken(location(), identifier.identifier) }
+Index         = "[" _ expr:Expression (_ ",")? _ "]" { return new IndexToken(location(), expr) }
 // Note: Full slice expressions are not supported.
-Slice         = "[" _ from:Expression? _ ":" _ to:Expression? _ "]" { return new SliceToken(from, to) }
+Slice         = "[" _ from:Expression? _ ":" _ to:Expression? _ "]" { return new SliceToken(location(), from, to) }
 TypeAssertion = "." _ "(" _ Type _ ")"
 // Note: Variadic arguments are not supported.
 // Note: Golang specs allow a Type to be the first argument, but it is only used for certain builtin functions.
 // We split BuiltinCall out to a separate token to allow parsing types as first argument.
-Arguments     = "(" _ exprs:ExpressionList? _ ","? _ ")" { return new CallToken(exprs) }
+Arguments     = "(" _ exprs:ExpressionList? _ ","? _ ")" { return new CallToken(location(), exprs) }
 
 //* Builtin Call (This is not in Golang specifications)
 BuiltinCall   = name:$[a-zA-Z]+ _ "(" _ type:Type _ args:("," _ @ExpressionList)? _ ")"
                 &{ return BuiltinCallToken.validNames.includes(name) && BuiltinCallToken.namesThatTakeType.includes(name) }
-                { return new BuiltinCallToken(name, type, args ?? []) }
+                { return new BuiltinCallToken(location(), name, type, args ?? []) }
               / name:$[a-zA-Z]+ _ "(" _ args:ExpressionList? _ ")"
                 &{ return BuiltinCallToken.validNames.includes(name) && !BuiltinCallToken.namesThatTakeType.includes(name) }
-                { return new BuiltinCallToken(name, null, args ?? []) }
+                { return new BuiltinCallToken(location(), name, null, args ?? []) }
 
 //* Method Expressions
 MethodExpr   = ReceiverType "." MethodName
@@ -336,33 +336,33 @@ UnaryExpr  = PrimaryExpr /
              op:unary_op _ expr:UnaryExpr { return op(expr) }
 
 // Operators are parsed into a function, that can be applied on operands to construct a token.
-rel_op      = "==" { return BinaryOperator.fromSource("equal") } /
-              "!=" { return BinaryOperator.fromSource("not_equal") } /
-              "<" !"-" { return BinaryOperator.fromSource("less") } /
-              "<=" { return BinaryOperator.fromSource("less_or_equal") } /
-              ">" { return BinaryOperator.fromSource("greater") } /
-              ">=" { return BinaryOperator.fromSource("greater_or_equal") }
-add_op      = "+" !"+" { return BinaryOperator.fromSource("sum") } /
-              "-" !"-" { return BinaryOperator.fromSource("difference") } /
-              "|" !"|" { return BinaryOperator.fromSource("bitwise_or") } /
-              "^" !"^" { return BinaryOperator.fromSource("bitwise_xor") }
-mul_op      = "*" !"*" { return BinaryOperator.fromSource("product") } /
-              "/" !"/" { return BinaryOperator.fromSource("quotient") } /
-              "%" { return BinaryOperator.fromSource("remainder") } /
-              "<<" { return BinaryOperator.fromSource("left_shift") } /
-              ">>" { return BinaryOperator.fromSource("right_shift") } /
-              "&" !"&" { return BinaryOperator.fromSource("bitwise_and") } /
-              "&^" { return BinaryOperator.fromSource("bit_clear") }
-disjunct_op = "||" { return BinaryOperator.fromSource("conditional_or") }
-conjunct_op = "&&" { return BinaryOperator.fromSource("conditional_and") }
+rel_op      = "==" { return BinaryOperator.fromSource(location(), "equal") } /
+              "!=" { return BinaryOperator.fromSource(location(), "not_equal") } /
+              "<" !"-" { return BinaryOperator.fromSource(location(), "less") } /
+              "<=" { return BinaryOperator.fromSource(location(), "less_or_equal") } /
+              ">" { return BinaryOperator.fromSource(location(), "greater") } /
+              ">=" { return BinaryOperator.fromSource(location(), "greater_or_equal") }
+add_op      = "+" !"+" { return BinaryOperator.fromSource(location(), "sum") } /
+              "-" !"-" { return BinaryOperator.fromSource(location(), "difference") } /
+              "|" !"|" { return BinaryOperator.fromSource(location(), "bitwise_or") } /
+              "^" !"^" { return BinaryOperator.fromSource(location(), "bitwise_xor") }
+mul_op      = "*" !"*" { return BinaryOperator.fromSource(location(), "product") } /
+              "/" !"/" { return BinaryOperator.fromSource(location(), "quotient") } /
+              "%" { return BinaryOperator.fromSource(location(), "remainder") } /
+              "<<" { return BinaryOperator.fromSource(location(), "left_shift") } /
+              ">>" { return BinaryOperator.fromSource(location(), "right_shift") } /
+              "&" !"&" { return BinaryOperator.fromSource(location(), "bitwise_and") } /
+              "&^" { return BinaryOperator.fromSource(location(), "bit_clear") }
+disjunct_op = "||" { return BinaryOperator.fromSource(location(), "conditional_or") }
+conjunct_op = "&&" { return BinaryOperator.fromSource(location(), "conditional_and") }
 
-unary_op   = "+" { return UnaryOperator.fromSource("plus") } / // Note: This operator is unnamed in Golang specs.
-             "-" { return UnaryOperator.fromSource("negation") } /
-             "!" { return UnaryOperator.fromSource("not") } /
-             "^" { return UnaryOperator.fromSource("bitwise_complement") } /
-             "*" { return UnaryOperator.fromSource("indirection") } /
-             "&" { return UnaryOperator.fromSource("address") } /
-             "<-" { return UnaryOperator.fromSource("receive") }
+unary_op   = "+" { return UnaryOperator.fromSource(location(), "plus") } / // Note: This operator is unnamed in Golang specs.
+             "-" { return UnaryOperator.fromSource(location(), "negation") } /
+             "!" { return UnaryOperator.fromSource(location(), "not") } /
+             "^" { return UnaryOperator.fromSource(location(), "bitwise_complement") } /
+             "*" { return UnaryOperator.fromSource(location(), "indirection") } /
+             "&" { return UnaryOperator.fromSource(location(), "address") } /
+             "<-" { return UnaryOperator.fromSource(location(), "receive") }
 
 //* Conversions
 Conversion = Type _ "(" _ Expression _ ")" _ ","? _ ")"
@@ -391,31 +391,31 @@ Label       = identifier
 ExpressionStmt = Expression
 
 //* Send Statements
-SendStmt = channel:Channel _ "<-" _ value:Expression { return new SendStatementToken(channel, value) }
+SendStmt = channel:Channel _ "<-" _ value:Expression { return new SendStatementToken(location(), channel, value) }
 // For simplicity, we only allow channels to be identifiers instead of Expression
 Channel  = identifier
 
 //* IncDec Statements
 IncDecStmt = expression:Expression _ op:("++" / "--")
-             { return new IncDecStatementToken(expression, op) }
+             { return new IncDecStatementToken(location(), expression, op) }
 
 //* Assignment Statements
 Assignment = left:ExpressionList _ op:$assign_op _ right:ExpressionList
-             { return new AssignmentStatementToken(left, op, right) }
+             { return new AssignmentStatementToken(location(), left, op, right) }
 assign_op  = [\*\+]? "="
 
 //* If Statements
 IfStmt = "if" _ init:(@SimpleStmt _ ";")? _ pred:Expression _ cons:Block _
          alt:("else" _ @(IfStmt / Block))?
-         { return new IfStatementToken(init, pred, cons, alt) }
+         { return new IfStatementToken(location(), init, pred, cons, alt) }
 
 //* Switch Statements
 SwitchStmt      = ExprSwitchStmt /** / TypeSwitchStmt */
 
 ExprSwitchStmt  = "switch" _ init:(@SimpleStmt _ ";")? _ expr:Expression? _ "{" _ cases:(_ @ExprCaseClause _)* "}"
-                  { return new SwitchStatementToken(init, expr, cases ) }
-ExprCaseClause = "case" _ "default" _ ":" _ statements:StatementList { return new SwitchCaseToken(null, statements) }
-               / "case" _ exprs:ExpressionList _ ":" _ statements:StatementList { return new SwitchCaseToken(exprs, statements) }
+                  { return new SwitchStatementToken(location(), init, expr, cases ) }
+ExprCaseClause = "case" _ "default" _ ":" _ statements:StatementList { return new SwitchCaseToken(location(), null, statements) }
+               / "case" _ exprs:ExpressionList _ ":" _ statements:StatementList { return new SwitchCaseToken(location(), exprs, statements) }
 
 // Note: TypeSwitchStmt will most likely not be supported.
 // TypeSwitchStmt  = "switch" _ (SimpleStmt _ ";")? _ TypeSwitchGuard _ "{" _ (_ TypeCaseClause _)* _ ")"
@@ -430,7 +430,7 @@ ForStmt   = "for" _
                     cond:Condition { return {init: undefined, cond, post: undefined }}
                     )?
             _ body:Block
-            { return new ForStatementToken(clause?.init, clause?.cond, clause?.post, body)}
+            { return new ForStatementToken(location(), clause?.init, clause?.cond, clause?.post, body)}
 Condition = Expression
 
 ForClause = init:InitStmt? _ ";" _ cond:Condition? _ ";" _ post:PostStmt?
@@ -442,42 +442,42 @@ RangeClause = (ExpressionList _ "=" / IdentifierList _ ":=")? _ "range" _ Expres
 
 //* Go Statements
 GoStmt = "go" _ expr:PrimaryExpr &{ return GoStatementToken.isValidGoroutine(expr) }
-         { return new GoStatementToken(expr) }
+         { return new GoStatementToken(location(), expr) }
 
 //* Select Statements
-SelectStmt = "select" _ "{" _ clauses:(_ @CommClause _)* _ "}" { return new SelectStatementToken(clauses ?? []) }
+SelectStmt = "select" _ "{" _ clauses:(_ @CommClause _)* _ "}" { return new SelectStatementToken(location(), clauses ?? []) }
 CommClause = predicate:CommCase _ ":" _ body:StatementList
-             { return new CommunicationClauseToken(predicate, body) }
+             { return new CommunicationClauseToken(location(), predicate, body) }
 CommCase   = "case" _ @(RecvStmt / SendStmt) / @"default"
 // For simplicity, we disallow an ExpressionList with assignment here.
 RecvStmt   = identifiers:IdentifierList _ ":=" _ expr:RecvExpr
              &{ return ReceiveStatementToken.isReceiveStatement(identifiers) }
-             { return new ReceiveStatementToken(true, identifiers, expr) } 
+             { return new ReceiveStatementToken(location(), true, identifiers, expr) } 
            / identifiers:(@IdentifierList _ "=")? _ expr:RecvExpr
              &{ return ReceiveStatementToken.isReceiveStatement(identifiers) }
-             { return new ReceiveStatementToken(false, identifiers, expr) } 
+             { return new ReceiveStatementToken(location(), false, identifiers, expr) } 
 RecvExpr   = expr:Expression &{ return expr instanceof UnaryOperator && expr.name === 'receive' } { return expr }
 
 //* Return Statements
 ReturnStmt = "return" _ returns:ExpressionList?
-             { return new ReturnStatementToken(returns) }
+             { return new ReturnStatementToken(location(), returns) }
 
 //* Break Statements
 //! TODO (P5): Labels are not tokenized.
-BreakStmt = "break" _ Label? { return new BreakStatementToken() }
+BreakStmt = "break" _ Label? { return new BreakStatementToken(location()) }
 
 //* Continue Statements
 //! TODO (P5): Labels are not tokenized.
-ContinueStmt = "continue" _ Label? { return new ContinueStatementToken() }
+ContinueStmt = "continue" _ Label? { return new ContinueStatementToken(location()) }
 
 //* Goto Statements
 GotoStmt = "goto" _ Label
 
 //* Fallthrough Statements
-FallthroughStmt = "fallthrough" { return new FallthroughStatementToken() }
+FallthroughStmt = "fallthrough" { return new FallthroughStatementToken(location()) }
 
 //* Defer Statements
-DeferStmt = "defer" _ expression:Expression { return new DeferStatementToken(expression) }
+DeferStmt = "defer" _ expression:Expression { return new DeferStatementToken(location(), expression) }
 
 
 
@@ -486,7 +486,7 @@ DeferStmt = "defer" _ expression:Expression { return new DeferStatementToken(exp
 //* =============== Packages ===============
 //* Source File
 SourceFile = pkg:PackageClause _ ";"? _ imports:(_ @ImportDecl _ ";"? _)* declarations:(_ @TopLevelDecl _ ";"?)*
-             { return new SourceFileToken(pkg, imports, declarations) }
+             { return new SourceFileToken(location(), pkg, imports, declarations) }
 
 //* Package Clause
 PackageClause = "package" _ @PackageName
@@ -495,5 +495,5 @@ PackageName = identifier
 //* Import Declarations
 ImportDecl = "import" _ @(ImportSpec / "(" _ (_ ImportSpec _ ";"?)* _ ")")
 ImportSpec = name:("." / PackageName)? _ path:ImportPath
-             { return new ImportToken(path, name) }
+             { return new ImportToken(location(), path, name) }
 ImportPath = string_lit

--- a/src/virtual-machine/parser/tokens/base.ts
+++ b/src/virtual-machine/parser/tokens/base.ts
@@ -1,4 +1,4 @@
-import { Compiler } from '../../compiler'
+import { CompileError, Compiler } from '../../compiler'
 import { Type } from '../../compiler/typing'
 
 export type TokenLocation = {
@@ -10,4 +10,15 @@ export abstract class Token {
   constructor(public type: string, public sourceLocation: TokenLocation) {}
 
   abstract compileUnchecked(compiler: Compiler): Type
+
+  compile(compiler: Compiler): Type {
+    try {
+      return this.compileUnchecked(compiler)
+    } catch (err) {
+      if (err instanceof CompileError) throw err
+
+      // Error originated from this token.
+      compiler.throwCompileError((err as Error).message, this.sourceLocation)
+    }
+  }
 }

--- a/src/virtual-machine/parser/tokens/base.ts
+++ b/src/virtual-machine/parser/tokens/base.ts
@@ -1,12 +1,13 @@
 import { Compiler } from '../../compiler'
 import { Type } from '../../compiler/typing'
 
-export abstract class Token {
-  type: string
+export type TokenLocation = {
+  start: { offset: number; line: number; column: number }
+  end: { offset: number; line: number; column: number }
+}
 
-  constructor(type: string) {
-    this.type = type
-  }
+export abstract class Token {
+  constructor(public type: string, public sourceLocation: TokenLocation) {}
 
   abstract compile(compiler: Compiler): Type
 }

--- a/src/virtual-machine/parser/tokens/base.ts
+++ b/src/virtual-machine/parser/tokens/base.ts
@@ -9,5 +9,5 @@ export type TokenLocation = {
 export abstract class Token {
   constructor(public type: string, public sourceLocation: TokenLocation) {}
 
-  abstract compile(compiler: Compiler): Type
+  abstract compileUnchecked(compiler: Compiler): Type
 }

--- a/src/virtual-machine/parser/tokens/block.ts
+++ b/src/virtual-machine/parser/tokens/block.ts
@@ -5,12 +5,16 @@ import {
 } from '../../compiler/instructions'
 import { NoType, ReturnType, Type } from '../../compiler/typing'
 
-import { Token } from './base'
+import { Token, TokenLocation } from './base'
 import { StatementToken } from './statement'
 
 export class BlockToken extends Token {
-  constructor(public statements: StatementToken[], public name = 'BLOCK') {
-    super('block')
+  constructor(
+    sourceLocation: TokenLocation,
+    public statements: StatementToken[],
+    public name = 'BLOCK',
+  ) {
+    super('block', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {

--- a/src/virtual-machine/parser/tokens/block.ts
+++ b/src/virtual-machine/parser/tokens/block.ts
@@ -17,14 +17,14 @@ export class BlockToken extends Token {
     super('block', sourceLocation)
   }
 
-  override compile(compiler: Compiler): Type {
+  override compileUnchecked(compiler: Compiler): Type {
     compiler.context.push_env()
     const block_instr = new BlockInstruction(this.name)
     compiler.instructions.push(block_instr)
     compiler.type_environment = compiler.type_environment.extend()
     let hasReturn = false
     for (const sub_token of this.statements) {
-      const statementType = sub_token.compile(compiler)
+      const statementType = sub_token.compileUnchecked(compiler)
       hasReturn ||= statementType instanceof ReturnType
     }
     const blockType = hasReturn

--- a/src/virtual-machine/parser/tokens/block.ts
+++ b/src/virtual-machine/parser/tokens/block.ts
@@ -24,7 +24,7 @@ export class BlockToken extends Token {
     compiler.type_environment = compiler.type_environment.extend()
     let hasReturn = false
     for (const sub_token of this.statements) {
-      const statementType = sub_token.compileUnchecked(compiler)
+      const statementType = sub_token.compile(compiler)
       hasReturn ||= statementType instanceof ReturnType
     }
     const blockType = hasReturn

--- a/src/virtual-machine/parser/tokens/declaration.ts
+++ b/src/virtual-machine/parser/tokens/declaration.ts
@@ -5,7 +5,7 @@ import {
 } from '../../compiler/instructions'
 import { NoType, Type } from '../../compiler/typing'
 
-import { Token } from './base'
+import { Token, TokenLocation } from './base'
 import { ExpressionToken } from './expressions'
 import { IdentifierToken } from './identifier'
 import { FunctionLiteralToken } from './literals'
@@ -16,8 +16,12 @@ export type TopLevelDeclarationToken =
   | FunctionDeclarationToken
 
 export class FunctionDeclarationToken extends Token {
-  constructor(public name: IdentifierToken, public func: FunctionLiteralToken) {
-    super('function_declaration')
+  constructor(
+    sourceLocation: TokenLocation,
+    public name: IdentifierToken,
+    public func: FunctionLiteralToken,
+  ) {
+    super('function_declaration', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -43,13 +47,12 @@ export class FunctionDeclarationToken extends Token {
 export abstract class DeclarationToken extends Token {}
 
 export class ShortVariableDeclarationToken extends DeclarationToken {
-  identifiers: IdentifierToken[]
-  expressions: ExpressionToken[]
-
-  constructor(identifiers: IdentifierToken[], expressions: ExpressionToken[]) {
-    super('short_variable_declaration')
-    this.identifiers = identifiers
-    this.expressions = expressions
+  constructor(
+    sourceLocation: TokenLocation,
+    public identifiers: IdentifierToken[],
+    public expressions: ExpressionToken[],
+  ) {
+    super('short_variable_declaration', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -71,12 +74,13 @@ export class ShortVariableDeclarationToken extends DeclarationToken {
 
 export class VariableDeclarationToken extends DeclarationToken {
   constructor(
+    sourceLocation: TokenLocation,
     public identifiers: IdentifierToken[],
     // Note: A variable declaration must have at least one of varType / expressions.
     public varType?: TypeToken,
     public expressions?: ExpressionToken[],
   ) {
-    super('variable_declaration')
+    super('variable_declaration', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -134,11 +138,12 @@ export class VariableDeclarationToken extends DeclarationToken {
 
 export class ConstantDeclarationToken extends DeclarationToken {
   constructor(
+    sourceLocation: TokenLocation,
     public identifiers: IdentifierToken[],
     public expressions: ExpressionToken[],
     public varType?: TypeToken,
   ) {
-    super('const_declaration')
+    super('const_declaration', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {

--- a/src/virtual-machine/parser/tokens/declaration.ts
+++ b/src/virtual-machine/parser/tokens/declaration.ts
@@ -33,9 +33,9 @@ export class FunctionDeclarationToken extends Token {
     //! no side effects, but would be nice to fix.
     compiler.type_environment.addType(
       this.name.identifier,
-      this.func.signature.compileUnchecked(compiler),
+      this.func.signature.compile(compiler),
     )
-    this.func.compileUnchecked(compiler)
+    this.func.compile(compiler)
     compiler.instructions.push(
       new LoadVariableInstruction(frame_idx, var_idx, this.name.identifier),
     )
@@ -61,7 +61,7 @@ export class ShortVariableDeclarationToken extends DeclarationToken {
       const var_name = identifiers[i].identifier
       const expr = expressions[i]
       const [frame_idx, var_idx] = compiler.context.env.declare_var(var_name)
-      const expressionType = expr.compileUnchecked(compiler)
+      const expressionType = expr.compile(compiler)
       compiler.type_environment.addType(var_name, expressionType)
       compiler.instructions.push(
         new LoadVariableInstruction(frame_idx, var_idx, var_name),
@@ -98,9 +98,7 @@ export class VariableDeclarationToken extends DeclarationToken {
       compiler.context.env.declare_var(identifier.identifier)
     }
 
-    const expectedType = varType
-      ? varType.compileUnchecked(compiler)
-      : undefined
+    const expectedType = varType ? varType.compile(compiler) : undefined
 
     // Compile and add identifiers to type environment.
     if (expressions) {
@@ -113,7 +111,7 @@ export class VariableDeclarationToken extends DeclarationToken {
         const identifier = identifiers[i].identifier
         const expression = expressions[i]
         const [frame_idx, var_idx] = compiler.context.env.find_var(identifier)
-        const expressionType = expression.compileUnchecked(compiler)
+        const expressionType = expression.compile(compiler)
         if (expectedType && !expectedType.assignableBy(expressionType)) {
           throw Error(
             `Cannot use ${expressionType} as ${expectedType} in variable declaration`,
@@ -156,14 +154,12 @@ export class ConstantDeclarationToken extends DeclarationToken {
      *  3. Compile Time Const: Evaluate Expression Token literal value and replace each reference (Golang only allow compile time const)
      */
     const { identifiers, varType, expressions } = this
-    const expectedType = varType
-      ? varType.compileUnchecked(compiler)
-      : undefined
+    const expectedType = varType ? varType.compile(compiler) : undefined
     for (let i = 0; i < identifiers.length; i++) {
       const var_name = identifiers[i].identifier
       const expr = expressions[i]
       const [frame_idx, var_idx] = compiler.context.env.declare_var(var_name)
-      const expressionType = expr.compileUnchecked(compiler)
+      const expressionType = expr.compile(compiler)
       if (expectedType && !expressionType.assignableBy(expectedType)) {
         throw Error(
           `Cannot use ${expressionType} as ${expectedType} in constant declaration`,

--- a/src/virtual-machine/parser/tokens/identifier.ts
+++ b/src/virtual-machine/parser/tokens/identifier.ts
@@ -40,7 +40,7 @@ export class IdentifierToken extends Token {
     return !reservedKeywords.includes(identifier)
   }
 
-  override compile(compiler: Compiler): Type {
+  override compileUnchecked(compiler: Compiler): Type {
     const [frame_idx, var_idx] = compiler.context.env.find_var(this.identifier)
     compiler.instructions.push(
       new LoadVariableInstruction(frame_idx, var_idx, this.identifier),
@@ -63,7 +63,7 @@ export class QualifiedIdentifierToken extends Token {
     super('qualified_identifier', sourceLocation)
   }
 
-  override compile(compiler: Compiler): Type {
+  override compileUnchecked(compiler: Compiler): Type {
     const pkg = compiler.type_environment.get(this.pkg)
     if (!(pkg instanceof PackageType)) {
       throw new Error(`${this} is not a type`)

--- a/src/virtual-machine/parser/tokens/identifier.ts
+++ b/src/virtual-machine/parser/tokens/identifier.ts
@@ -2,11 +2,11 @@ import { Compiler } from '../../compiler'
 import { LoadVariableInstruction } from '../../compiler/instructions'
 import { PackageType, Type } from '../../compiler/typing'
 
-import { Token } from './base'
+import { Token, TokenLocation } from './base'
 
 export class IdentifierToken extends Token {
-  constructor(public identifier: string) {
-    super('identifier')
+  constructor(sourceLocation: TokenLocation, public identifier: string) {
+    super('identifier', sourceLocation)
   }
 
   static isValidIdentifier(identifier: string): boolean {
@@ -55,8 +55,12 @@ export class IdentifierToken extends Token {
  * hence all values (not types) of the form `x.y` are handled by selector operator instead.
  */
 export class QualifiedIdentifierToken extends Token {
-  constructor(public pkg: string, public identifier: string) {
-    super('qualified_identifier')
+  constructor(
+    sourceLocation: TokenLocation,
+    public pkg: string,
+    public identifier: string,
+  ) {
+    super('qualified_identifier', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {

--- a/src/virtual-machine/parser/tokens/literals.ts
+++ b/src/virtual-machine/parser/tokens/literals.ts
@@ -19,14 +19,14 @@ import {
   Type,
 } from '../../compiler/typing'
 
-import { Token } from './base'
+import { Token, TokenLocation } from './base'
 import { BlockToken } from './block'
 import { ExpressionToken } from './expressions'
 import { ArrayTypeToken, FunctionTypeToken, SliceTypeToken } from './type'
 
 export abstract class LiteralToken extends Token {
-  constructor(public value: number | string) {
-    super('literal')
+  constructor(sourceLocation: TokenLocation, public value: number | string) {
+    super('literal', sourceLocation)
   }
 
   static is(token: Token): token is LiteralToken {
@@ -36,10 +36,10 @@ export abstract class LiteralToken extends Token {
 
 export class IntegerLiteralToken extends LiteralToken {
   /** Tokenize an integer literal in the given base. */
-  static fromSource(str: string, base: number) {
+  static fromSource(sourceLocation: TokenLocation, str: string, base: number) {
     // Golang numbers can be underscore delimited.
     const value = parseInt(str.replace('_', ''), base)
-    return new IntegerLiteralToken(value)
+    return new IntegerLiteralToken(sourceLocation, value)
   }
 
   getValue(): number {
@@ -56,9 +56,9 @@ export class IntegerLiteralToken extends LiteralToken {
 
 export class FloatLiteralToken extends LiteralToken {
   /** Tokenize a float literal. */
-  static fromSource(str: string) {
+  static fromSource(sourceLocation: TokenLocation, str: string) {
     const value = parseFloat(str)
-    return new FloatLiteralToken(value)
+    return new FloatLiteralToken(sourceLocation, value)
   }
 
   getValue(): number {
@@ -75,15 +75,15 @@ export class FloatLiteralToken extends LiteralToken {
 
 export class StringLiteralToken extends LiteralToken {
   /** Tokenize a raw string literal. */
-  static fromSourceRaw(str: string) {
+  static fromSourceRaw(sourceLocation: TokenLocation, str: string) {
     // Carriage returns are discarded from raw strings.
     str = str.replaceAll('\r', '')
-    return new StringLiteralToken(str)
+    return new StringLiteralToken(sourceLocation, str)
   }
 
   /** Tokenize an interpreted string literal. */
-  static fromSourceInterpreted(str: string) {
-    return new StringLiteralToken(str)
+  static fromSourceInterpreted(sourceLocation: TokenLocation, str: string) {
+    return new StringLiteralToken(sourceLocation, str)
   }
 
   getValue(): string {
@@ -99,8 +99,12 @@ export class StringLiteralToken extends LiteralToken {
 }
 
 export class FunctionLiteralToken extends Token {
-  constructor(public signature: FunctionTypeToken, public body: BlockToken) {
-    super('function_literal')
+  constructor(
+    sourceLocation: TokenLocation,
+    public signature: FunctionTypeToken,
+    public body: BlockToken,
+  ) {
+    super('function_literal', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -149,8 +153,11 @@ export class FunctionLiteralToken extends Token {
 }
 
 export class LiteralValueToken extends Token {
-  constructor(public elements: (LiteralValueToken | ExpressionToken)[]) {
-    super('literal_value')
+  constructor(
+    sourceLocation: TokenLocation,
+    public elements: (LiteralValueToken | ExpressionToken)[],
+  ) {
+    super('literal_value', sourceLocation)
   }
 
   override compile(_compiler: Compiler): Type {
@@ -217,10 +224,11 @@ export class LiteralValueToken extends Token {
 
 export class ArrayLiteralToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public arrayType: ArrayTypeToken,
     public body: LiteralValueToken,
   ) {
-    super('array_literal')
+    super('array_literal', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -232,10 +240,11 @@ export class ArrayLiteralToken extends Token {
 
 export class SliceLiteralToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public sliceType: SliceTypeToken,
     public body: LiteralValueToken,
   ) {
-    super('slice_literal')
+    super('slice_literal', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {

--- a/src/virtual-machine/parser/tokens/operator.ts
+++ b/src/virtual-machine/parser/tokens/operator.ts
@@ -8,28 +8,33 @@ import {
 } from '../../compiler/instructions'
 import { BoolType, ChannelType, Type } from '../../compiler/typing'
 
-import { Token } from './base'
+import { Token, TokenLocation } from './base'
 
 abstract class Operator extends Token {
   name: string
   children: Token[]
 
-  constructor(type: string, name: string, children: Token[]) {
-    super(type)
+  constructor(
+    type: string,
+    sourceLocation: TokenLocation,
+    name: string,
+    children: Token[],
+  ) {
+    super(type, sourceLocation)
     this.name = name
     this.children = children
   }
 }
 
 export class UnaryOperator extends Operator {
-  constructor(name: string, child: Token) {
-    super('unary_operator', name, [child])
+  constructor(sourceLocation: TokenLocation, name: string, child: Token) {
+    super('unary_operator', sourceLocation, name, [child])
   }
 
   /** Returns a function that can be applied on its child token to create a UnaryOperator. */
-  static fromSource(name: string) {
+  static fromSource(sourceLocation: TokenLocation, name: string) {
     return (child: Token) => {
-      return new UnaryOperator(name, child)
+      return new UnaryOperator(sourceLocation, name, child)
     }
   }
 
@@ -53,14 +58,19 @@ export class UnaryOperator extends Operator {
 }
 
 export class BinaryOperator extends Operator {
-  constructor(name: string, left: Token, right: Token) {
-    super('binary_operator', name, [left, right])
+  constructor(
+    sourceLocation: TokenLocation,
+    name: string,
+    left: Token,
+    right: Token,
+  ) {
+    super('binary_operator', sourceLocation, name, [left, right])
   }
 
   /** Returns a function that can be applied on its children tokens to create a BinaryOperator. */
-  static fromSource(name: string) {
+  static fromSource(sourceLocation: TokenLocation, name: string) {
     return (left: Token, right: Token) => {
-      return new BinaryOperator(name, left, right)
+      return new BinaryOperator(sourceLocation, name, left, right)
     }
   }
 

--- a/src/virtual-machine/parser/tokens/operator.ts
+++ b/src/virtual-machine/parser/tokens/operator.ts
@@ -39,7 +39,7 @@ export class UnaryOperator extends Operator {
   }
 
   override compileUnchecked(compiler: Compiler): Type {
-    const expressionType = this.children[0].compileUnchecked(compiler)
+    const expressionType = this.children[0].compile(compiler)
     if (this.name === 'receive') {
       if (!(expressionType instanceof ChannelType))
         throw Error('Receive Expression not chan')
@@ -75,8 +75,8 @@ export class BinaryOperator extends Operator {
   }
 
   override compileUnchecked(compiler: Compiler): Type {
-    const leftType = this.children[0].compileUnchecked(compiler)
-    const rightType = this.children[1].compileUnchecked(compiler)
+    const leftType = this.children[0].compile(compiler)
+    const rightType = this.children[1].compile(compiler)
     if (!leftType.equals(rightType)) {
       throw Error(
         `Invalid operation (mismatched types ${leftType} and ${rightType})`,

--- a/src/virtual-machine/parser/tokens/operator.ts
+++ b/src/virtual-machine/parser/tokens/operator.ts
@@ -38,8 +38,8 @@ export class UnaryOperator extends Operator {
     }
   }
 
-  override compile(compiler: Compiler): Type {
-    const expressionType = this.children[0].compile(compiler)
+  override compileUnchecked(compiler: Compiler): Type {
+    const expressionType = this.children[0].compileUnchecked(compiler)
     if (this.name === 'receive') {
       if (!(expressionType instanceof ChannelType))
         throw Error('Receive Expression not chan')
@@ -74,9 +74,9 @@ export class BinaryOperator extends Operator {
     }
   }
 
-  override compile(compiler: Compiler): Type {
-    const leftType = this.children[0].compile(compiler)
-    const rightType = this.children[1].compile(compiler)
+  override compileUnchecked(compiler: Compiler): Type {
+    const leftType = this.children[0].compileUnchecked(compiler)
+    const rightType = this.children[1].compileUnchecked(compiler)
     if (!leftType.equals(rightType)) {
       throw Error(
         `Invalid operation (mismatched types ${leftType} and ${rightType})`,

--- a/src/virtual-machine/parser/tokens/source_file.ts
+++ b/src/virtual-machine/parser/tokens/source_file.ts
@@ -23,7 +23,7 @@ export class SourceFileToken extends Token {
     super('source_file', sourceLocation)
   }
 
-  override compile(compiler: Compiler): Type {
+  override compileUnchecked(compiler: Compiler): Type {
     // Setup.
     const global_block = new BlockInstruction('GLOBAL')
     compiler.instructions.push(global_block)
@@ -31,14 +31,14 @@ export class SourceFileToken extends Token {
     compiler.type_environment = compiler.type_environment.extend()
 
     // Compile imports.
-    for (const imp of this.imports ?? []) imp.compile(compiler)
+    for (const imp of this.imports ?? []) imp.compileUnchecked(compiler)
 
     // Declare builtin constants for `true` and `false`.
     this.predeclareConstants(compiler)
 
     // Compile top level declarations.
     for (const declaration of this.declarations || []) {
-      declaration.compile(compiler)
+      declaration.compileUnchecked(compiler)
     }
 
     // Call main function.
@@ -90,7 +90,7 @@ export class ImportToken extends Token {
     super('import', sourceLocation)
   }
 
-  override compile(compiler: Compiler): Type {
+  override compileUnchecked(compiler: Compiler): Type {
     const pkg = this.importPath.getValue()
     if (pkg in builtinPackages) {
       builtinPackages[pkg as keyof typeof builtinPackages](compiler)

--- a/src/virtual-machine/parser/tokens/source_file.ts
+++ b/src/virtual-machine/parser/tokens/source_file.ts
@@ -31,14 +31,14 @@ export class SourceFileToken extends Token {
     compiler.type_environment = compiler.type_environment.extend()
 
     // Compile imports.
-    for (const imp of this.imports ?? []) imp.compileUnchecked(compiler)
+    for (const imp of this.imports ?? []) imp.compile(compiler)
 
     // Declare builtin constants for `true` and `false`.
     this.predeclareConstants(compiler)
 
     // Compile top level declarations.
     for (const declaration of this.declarations || []) {
-      declaration.compileUnchecked(compiler)
+      declaration.compile(compiler)
     }
 
     // Call main function.

--- a/src/virtual-machine/parser/tokens/source_file.ts
+++ b/src/virtual-machine/parser/tokens/source_file.ts
@@ -9,17 +9,18 @@ import {
 import { BoolType, NoType, Type } from '../../compiler/typing'
 import { builtinPackages } from '../../compiler/typing/packages'
 
-import { Token } from './base'
+import { Token, TokenLocation } from './base'
 import { TopLevelDeclarationToken } from './declaration'
 import { StringLiteralToken } from './literals'
 
 export class SourceFileToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public pkg: string,
     public imports: ImportToken[] | null,
     public declarations: TopLevelDeclarationToken[] | null,
   ) {
-    super('source_file')
+    super('source_file', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -82,10 +83,11 @@ export class SourceFileToken extends Token {
 
 export class ImportToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public importPath: StringLiteralToken,
     public pkgName: string | null,
   ) {
-    super('import')
+    super('import', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {

--- a/src/virtual-machine/parser/tokens/statement.ts
+++ b/src/virtual-machine/parser/tokens/statement.ts
@@ -29,7 +29,7 @@ import {
   Type,
 } from '../../compiler/typing'
 
-import { Token } from './base'
+import { Token, TokenLocation } from './base'
 import { BlockToken } from './block'
 import { DeclarationToken, ShortVariableDeclarationToken } from './declaration'
 import {
@@ -65,11 +65,12 @@ export type SimpleStatementToken =
 
 export class AssignmentStatementToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public left: ExpressionToken[],
     public operation: '=' | '+=' | '*=',
     public right: ExpressionToken[],
   ) {
-    super('assignment')
+    super('assignment', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -115,10 +116,11 @@ export class AssignmentStatementToken extends Token {
 
 export class IncDecStatementToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public expression: ExpressionToken,
     public operation: '++' | '--',
   ) {
-    super('inc_dec')
+    super('inc_dec', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -137,8 +139,11 @@ export class IncDecStatementToken extends Token {
 }
 
 export class ReturnStatementToken extends Token {
-  constructor(public returns?: ExpressionToken[]) {
-    super('return')
+  constructor(
+    sourceLocation: TokenLocation,
+    public returns?: ExpressionToken[],
+  ) {
+    super('return', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -167,8 +172,8 @@ export class ReturnStatementToken extends Token {
 }
 
 export class BreakStatementToken extends Token {
-  constructor() {
-    super('break')
+  constructor(sourceLocation: TokenLocation) {
+    super('break', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -180,8 +185,8 @@ export class BreakStatementToken extends Token {
 }
 
 export class ContinueStatementToken extends Token {
-  constructor() {
-    super('continue')
+  constructor(sourceLocation: TokenLocation) {
+    super('continue', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -193,8 +198,8 @@ export class ContinueStatementToken extends Token {
 }
 
 export class FallthroughStatementToken extends Token {
-  constructor() {
-    super('fallthrough')
+  constructor(sourceLocation: TokenLocation) {
+    super('fallthrough', sourceLocation)
   }
 
   override compile(_compiler: Compiler): Type {
@@ -205,13 +210,14 @@ export class FallthroughStatementToken extends Token {
 
 export class IfStatementToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     /** Executed before the predicate (e.g. if x := 0; x < 1 {} ) */
     public initialization: SimpleStatementToken | null,
     public predicate: ExpressionToken,
     public consequent: BlockToken,
     public alternative: IfStatementToken | BlockToken | null,
   ) {
-    super('if')
+    super('if', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -270,11 +276,12 @@ export class IfStatementToken extends Token {
 
 export class SwitchStatementToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public init: SimpleStatementToken | null,
     public expressions: ExpressionToken | null,
     public cases: SwitchCaseToken[],
   ) {
-    super('switch')
+    super('switch', sourceLocation)
   }
 
   override compile(_compiler: Compiler): Type {
@@ -285,10 +292,11 @@ export class SwitchStatementToken extends Token {
 
 export class SwitchCaseToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public expressions: ExpressionToken[] | null,
     public statements: StatementToken[],
   ) {
-    super('case')
+    super('case', sourceLocation)
   }
 
   override compile(_compiler: Compiler): Type {
@@ -305,12 +313,13 @@ export class ForStatementToken extends Token {
   // 4. For statements with a range clause.
   //! Note that range clauses are not supported for now. They will likely be a seperate class.
   constructor(
+    sourceLocation: TokenLocation,
     public initialization: SimpleStatementToken | null,
     public condition: ExpressionToken | null,
     public post: ExpressionToken | null,
     public body: BlockToken,
   ) {
-    super('for')
+    super('for', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -356,8 +365,11 @@ export class ForStatementToken extends Token {
 }
 
 export class DeferStatementToken extends Token {
-  constructor(public expression: ExpressionToken) {
-    super('defer')
+  constructor(
+    sourceLocation: TokenLocation,
+    public expression: ExpressionToken,
+  ) {
+    super('defer', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -383,8 +395,11 @@ export class DeferStatementToken extends Token {
 }
 
 export class GoStatementToken extends Token {
-  constructor(public call: PrimaryExpressionToken) {
-    super('go')
+  constructor(
+    sourceLocation: TokenLocation,
+    public call: PrimaryExpressionToken,
+  ) {
+    super('go', sourceLocation)
   }
 
   /** Used in the parser to only parse function calls */
@@ -408,8 +423,12 @@ export class GoStatementToken extends Token {
 
 /** Sends a `value` into `channel`. */
 export class SendStatementToken extends Token {
-  constructor(public channel: IdentifierToken, public value: ExpressionToken) {
-    super('send')
+  constructor(
+    sourceLocation: TokenLocation,
+    public channel: IdentifierToken,
+    public value: ExpressionToken,
+  ) {
+    super('send', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -433,13 +452,14 @@ export class SendStatementToken extends Token {
 /** Receive and assign the results to one or two variables. Note that RecvStmt is NOT a SimpleStmt. */
 export class ReceiveStatementToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     /** Whether this is a shorthand variable declaration (else it is an assignment). */
     public declaration: boolean,
     public identifiers: IdentifierToken[] | null,
     /** expression is guarenteed to be a receive operator. */
     public expression: UnaryOperator,
   ) {
-    super('receive')
+    super('receive', sourceLocation)
   }
 
   /** Used in the parser to only parse valid receive statements. */
@@ -457,8 +477,11 @@ export class ReceiveStatementToken extends Token {
 }
 
 export class SelectStatementToken extends Token {
-  constructor(public clauses: CommunicationClauseToken[]) {
-    super('select')
+  constructor(
+    sourceLocation: TokenLocation,
+    public clauses: CommunicationClauseToken[],
+  ) {
+    super('select', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -500,10 +523,11 @@ export class SelectStatementToken extends Token {
 }
 export class CommunicationClauseToken extends Token {
   constructor(
+    sourceLocation: TokenLocation,
     public predicate: 'default' | SendStatementToken | ReceiveStatementToken,
     public body: StatementToken[],
   ) {
-    super('communication_clause')
+    super('communication_clause', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {
@@ -521,7 +545,9 @@ export class CommunicationClauseToken extends Token {
       }
       const jump_instr = new JumpInstruction()
       compiler.instructions.push(jump_instr)
-      new BlockToken(this.body, 'CASE BLOCK').compile(compiler)
+      new BlockToken(this.sourceLocation, this.body, 'CASE BLOCK').compile(
+        compiler,
+      )
       jump_instr.set_addr(compiler.instructions.length + 1)
     } else {
       // This is recv statement
@@ -532,22 +558,33 @@ export class CommunicationClauseToken extends Token {
       if (this.predicate.identifiers) {
         if (this.predicate.declaration) {
           this.body.unshift(
-            new ShortVariableDeclarationToken(this.predicate.identifiers, [
-              new EmptyExpressionToken(chanType),
-            ]),
+            new ShortVariableDeclarationToken(
+              this.sourceLocation,
+              this.predicate.identifiers,
+              [new EmptyExpressionToken(this.sourceLocation, chanType)],
+            ),
           )
         } else {
           // !TODO: Hacky see if better way to implement this
           this.body.unshift(
             new AssignmentStatementToken(
-              [new PrimaryExpressionToken(this.predicate.identifiers[0], null)],
+              this.sourceLocation,
+              [
+                new PrimaryExpressionToken(
+                  this.sourceLocation,
+                  this.predicate.identifiers[0],
+                  null,
+                ),
+              ],
               '=',
-              [new EmptyExpressionToken(chanType)],
+              [new EmptyExpressionToken(this.sourceLocation, chanType)],
             ),
           )
         }
       } else compiler.instructions.push(new PopInstruction())
-      new BlockToken(this.body, 'CASE BLOCK').compile(compiler)
+      new BlockToken(this.sourceLocation, this.body, 'CASE BLOCK').compile(
+        compiler,
+      )
       jump_instr.set_addr(compiler.instructions.length + 1)
     }
     return new NoType()
@@ -556,8 +593,11 @@ export class CommunicationClauseToken extends Token {
 
 /** An ExpressionStatement differs from an Expression: it should not leave a value on the OS. */
 export class ExpressionStatementToken extends Token {
-  constructor(public expression: ExpressionToken) {
-    super('expression_statement')
+  constructor(
+    sourceLocation: TokenLocation,
+    public expression: ExpressionToken,
+  ) {
+    super('expression_statement', sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {

--- a/src/virtual-machine/parser/tokens/type.ts
+++ b/src/virtual-machine/parser/tokens/type.ts
@@ -76,10 +76,7 @@ export class ArrayTypeToken extends TypeToken {
   }
 
   override compileUnchecked(compiler: Compiler): ArrayType {
-    return new ArrayType(
-      this.element.compileUnchecked(compiler),
-      this.length.getValue(),
-    )
+    return new ArrayType(this.element.compile(compiler), this.length.getValue())
   }
 }
 
@@ -89,7 +86,7 @@ export class SliceTypeToken extends TypeToken {
   }
 
   override compileUnchecked(compiler: Compiler): SliceType {
-    return new SliceType(this.element.compileUnchecked(compiler))
+    return new SliceType(this.element.compile(compiler))
   }
 }
 
@@ -113,10 +110,10 @@ export class FunctionTypeToken extends TypeToken {
 
   override compileUnchecked(compiler: Compiler): FunctionType {
     const parameterTypes = this.parameters.map(
-      (p) => new ParameterType(p.identifier, p.type.compileUnchecked(compiler)),
+      (p) => new ParameterType(p.identifier, p.type.compile(compiler)),
     )
     const resultTypes = new ReturnType(
-      this.results.map((r) => r.type.compileUnchecked(compiler)),
+      this.results.map((r) => r.type.compile(compiler)),
     )
     return new FunctionType(parameterTypes, resultTypes)
   }
@@ -149,7 +146,7 @@ export class ChannelTypeToken extends TypeToken {
 
   override compileUnchecked(compiler: Compiler): Type {
     return new ChannelType(
-      this.element.compileUnchecked(compiler),
+      this.element.compile(compiler),
       this.readable,
       this.writable,
     )

--- a/src/virtual-machine/parser/tokens/type.ts
+++ b/src/virtual-machine/parser/tokens/type.ts
@@ -56,7 +56,7 @@ export class PrimitiveTypeToken extends TypeToken {
     this.name = name
   }
 
-  override compile(_compiler: Compiler): Type {
+  override compileUnchecked(_compiler: Compiler): Type {
     if (this.name === 'bool') return new BoolType()
     else if (this.name === 'float64') return new Float64Type()
     else if (this.name === 'int') return new Int64Type()
@@ -75,8 +75,11 @@ export class ArrayTypeToken extends TypeToken {
     super(sourceLocation)
   }
 
-  override compile(compiler: Compiler): ArrayType {
-    return new ArrayType(this.element.compile(compiler), this.length.getValue())
+  override compileUnchecked(compiler: Compiler): ArrayType {
+    return new ArrayType(
+      this.element.compileUnchecked(compiler),
+      this.length.getValue(),
+    )
   }
 }
 
@@ -85,8 +88,8 @@ export class SliceTypeToken extends TypeToken {
     super(sourceLocation)
   }
 
-  override compile(compiler: Compiler): SliceType {
-    return new SliceType(this.element.compile(compiler))
+  override compileUnchecked(compiler: Compiler): SliceType {
+    return new SliceType(this.element.compileUnchecked(compiler))
   }
 }
 
@@ -108,12 +111,12 @@ export class FunctionTypeToken extends TypeToken {
     this.results = results ?? []
   }
 
-  override compile(compiler: Compiler): FunctionType {
+  override compileUnchecked(compiler: Compiler): FunctionType {
     const parameterTypes = this.parameters.map(
-      (p) => new ParameterType(p.identifier, p.type.compile(compiler)),
+      (p) => new ParameterType(p.identifier, p.type.compileUnchecked(compiler)),
     )
     const resultTypes = new ReturnType(
-      this.results.map((r) => r.type.compile(compiler)),
+      this.results.map((r) => r.type.compileUnchecked(compiler)),
     )
     return new FunctionType(parameterTypes, resultTypes)
   }
@@ -128,7 +131,7 @@ export class MapTypeToken extends TypeToken {
     super(sourceLocation)
   }
 
-  override compile(_compiler: Compiler): Type {
+  override compileUnchecked(_compiler: Compiler): Type {
     //! TODO: Implement.
     return new NoType()
   }
@@ -144,9 +147,9 @@ export class ChannelTypeToken extends TypeToken {
     super(sourceLocation)
   }
 
-  override compile(compiler: Compiler): Type {
+  override compileUnchecked(compiler: Compiler): Type {
     return new ChannelType(
-      this.element.compile(compiler),
+      this.element.compileUnchecked(compiler),
       this.readable,
       this.writable,
     )

--- a/src/virtual-machine/parser/tokens/type.ts
+++ b/src/virtual-machine/parser/tokens/type.ts
@@ -14,12 +14,12 @@ import {
   Type,
 } from '../../compiler/typing'
 
-import { Token } from './base'
+import { Token, TokenLocation } from './base'
 import { IntegerLiteralToken } from './literals'
 
 export abstract class TypeToken extends Token {
-  constructor() {
-    super('type')
+  constructor(sourceLocation: TokenLocation) {
+    super('type', sourceLocation)
   }
 }
 
@@ -48,8 +48,8 @@ export class PrimitiveTypeToken extends TypeToken {
 
   name: (typeof PrimitiveTypeToken.primitiveTypes)[number]
 
-  constructor(name: string) {
-    super()
+  constructor(sourceLocation: TokenLocation, name: string) {
+    super(sourceLocation)
     if (!PrimitiveTypeToken.isPrimitive(name)) {
       throw Error(`Invalid primitive type: ${name}`)
     }
@@ -67,8 +67,12 @@ export class PrimitiveTypeToken extends TypeToken {
 }
 
 export class ArrayTypeToken extends TypeToken {
-  constructor(public element: TypeToken, public length: IntegerLiteralToken) {
-    super()
+  constructor(
+    sourceLocation: TokenLocation,
+    public element: TypeToken,
+    public length: IntegerLiteralToken,
+  ) {
+    super(sourceLocation)
   }
 
   override compile(compiler: Compiler): ArrayType {
@@ -77,8 +81,8 @@ export class ArrayTypeToken extends TypeToken {
 }
 
 export class SliceTypeToken extends TypeToken {
-  constructor(public element: TypeToken) {
-    super()
+  constructor(sourceLocation: TokenLocation, public element: TypeToken) {
+    super(sourceLocation)
   }
 
   override compile(compiler: Compiler): SliceType {
@@ -94,8 +98,12 @@ export class FunctionTypeToken extends TypeToken {
   public parameters: ParameterDecl[]
   public results: ParameterDecl[]
 
-  constructor(parameters: ParameterDecl[], results: ParameterDecl[] | null) {
-    super()
+  constructor(
+    sourceLocation: TokenLocation,
+    parameters: ParameterDecl[],
+    results: ParameterDecl[] | null,
+  ) {
+    super(sourceLocation)
     this.parameters = parameters
     this.results = results ?? []
   }
@@ -112,8 +120,12 @@ export class FunctionTypeToken extends TypeToken {
 }
 
 export class MapTypeToken extends TypeToken {
-  constructor(public key: TypeToken, public element: TypeToken) {
-    super()
+  constructor(
+    sourceLocation: TokenLocation,
+    public key: TypeToken,
+    public element: TypeToken,
+  ) {
+    super(sourceLocation)
   }
 
   override compile(_compiler: Compiler): Type {
@@ -124,11 +136,12 @@ export class MapTypeToken extends TypeToken {
 
 export class ChannelTypeToken extends TypeToken {
   constructor(
+    sourceLocation: TokenLocation,
     public element: TypeToken,
     public readable: boolean,
     public writable: boolean,
   ) {
-    super()
+    super(sourceLocation)
   }
 
   override compile(compiler: Compiler): Type {

--- a/tests/array.test.ts
+++ b/tests/array.test.ts
@@ -5,7 +5,7 @@ import { mainRunner } from './utility'
 describe('Array Type Checking', () => {
   test('Array literal with more elements than in the type should fail.', () => {
     expect(
-      mainRunner('var a [3]int = [3]int{1, 2, 3, 4}').errorMessage,
+      mainRunner('var a [3]int = [3]int{1, 2, 3, 4}').error?.message,
     ).toEqual(
       'Array literal has 4 elements but only expected 3, in type [3]int64.',
     )
@@ -13,14 +13,14 @@ describe('Array Type Checking', () => {
 
   test('Array literal must have the same type as the declared type.', () => {
     expect(
-      mainRunner('var a [3]int = [3]int{1, "wrong type", 3}').errorMessage,
+      mainRunner('var a [3]int = [3]int{1, "wrong type", 3}').error?.message,
     ).toEqual('Cannot use string as int64 value in array literal.')
   })
 
   test('Array indexing with non integer type should fail.', () => {
     expect(
-      mainRunner('var a [3]int = [3]int{1, 2, 3}; fmt.Println(a[1.2])')
-        .errorMessage,
+      mainRunner('var a [3]int = [3]int{1, 2, 3}; fmt.Println(a[1.2])').error
+        ?.message,
     ).toEqual('Invalid argument: Index has type float64 but must be an integer')
   })
 })
@@ -38,7 +38,7 @@ describe('Array Execution', () => {
     expect(
       mainRunner(
         'var a [3]string = [3]string{"a", "b", "c"}\n fmt.Println(a[-1])',
-      ).errorMessage,
+      ).error?.message,
     ).toEqual('Execution Error: Index out of range [-1] with length 3')
   })
 
@@ -46,7 +46,7 @@ describe('Array Execution', () => {
     expect(
       mainRunner(
         'var a [3]string = [3]string{"a", "b", "c"}\n fmt.Println(a[3])',
-      ).errorMessage,
+      ).error?.message,
     ).toEqual('Execution Error: Index out of range [3] with length 3')
   })
 

--- a/tests/builtin.test.ts
+++ b/tests/builtin.test.ts
@@ -5,7 +5,7 @@ import { mainRunner } from './utility'
 describe('Builtins Type Checking', () => {
   test('Assignment of make with incompatible type should fail', () => {
     expect(
-      mainRunner('var a chan int = make(chan string)').errorMessage,
+      mainRunner('var a chan int = make(chan string)').error?.message,
     ).toEqual('Cannot use chan string as chan int64 in variable declaration')
   })
 })

--- a/tests/channel.test.ts
+++ b/tests/channel.test.ts
@@ -4,7 +4,7 @@ import { mainRunner } from './utility'
 
 describe('Channel Tests', () => {
   test('Assign int to channel should fail', () => {
-    expect(mainRunner('var a <-chan int = 1').errorMessage).toEqual(
+    expect(mainRunner('var a <-chan int = 1').error?.message).toEqual(
       'Cannot use int64 as <-chan int64 in variable declaration',
     )
   })

--- a/tests/defer.test.ts
+++ b/tests/defer.test.ts
@@ -9,7 +9,7 @@ describe('Defer Type Checking', () => {
     const code = `
     defer "hello"
     `
-    expect(mainRunner(code).errorMessage).toEqual(
+    expect(mainRunner(code).error?.message).toEqual(
       'Expression in defer must be function call.',
     )
   })

--- a/tests/fmt.test.ts
+++ b/tests/fmt.test.ts
@@ -7,7 +7,9 @@ describe('fmt Type Checking', () => {
     const code = `
     fmt.nonexistent("hi")
     `
-    expect(mainRunner(code).errorMessage).toEqual('undefined: fmt.nonexistent')
+    expect(mainRunner(code).error?.message).toEqual(
+      'undefined: fmt.nonexistent',
+    )
   })
 })
 

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -7,7 +7,8 @@ import { mainRunner } from './utility'
 describe('Function Type Checking', () => {
   test('Function assignment', () => {
     expect(
-      mainRunner('var a func(int, int) = func(int, int, int) {}').errorMessage,
+      mainRunner('var a func(int, int) = func(int, int, int) {}').error
+        ?.message,
     ).toEqual(
       'Cannot use func(int64, int64, int64) () as func(int64, int64) () in variable declaration',
     )
@@ -15,7 +16,7 @@ describe('Function Type Checking', () => {
 
   test('Function call - too many arguments', () => {
     expect(
-      mainRunner('f := func(int, int) {}; f(1, 2, 3)').errorMessage,
+      mainRunner('f := func(int, int) {}; f(1, 2, 3)').error?.message,
     ).toEqual(
       'Too many arguments in function call\n' +
         'have (int64, int64, int64)\n' +
@@ -24,7 +25,7 @@ describe('Function Type Checking', () => {
   })
 
   test('Function call - too few arguments', () => {
-    expect(mainRunner('f := func(int, int) {}; f(1)').errorMessage).toEqual(
+    expect(mainRunner('f := func(int, int) {}; f(1)').error?.message).toEqual(
       'Not enough arguments in function call\n' +
         'have (int64)\n' +
         'want (int64, int64)',
@@ -33,12 +34,12 @@ describe('Function Type Checking', () => {
 
   test('Function call - incorrect argument type', () => {
     expect(
-      mainRunner('f := func(int, int) {}; f(1, "a")').errorMessage,
+      mainRunner('f := func(int, int) {}; f(1, "a")').error?.message,
     ).toEqual('Cannot use string as int64 in argument to function call')
   })
 
   test('Function missing return', () => {
-    expect(mainRunner('f := func(x int) int { x += 1}').errorMessage).toEqual(
+    expect(mainRunner('f := func(x int) int { x += 1}').error?.message).toEqual(
       'Missing return.',
     )
   })
@@ -47,7 +48,7 @@ describe('Function Type Checking', () => {
     expect(
       mainRunner(
         'f := func(x int) int { if x == 1 { x += 1 } else { return 1 } }',
-      ).errorMessage,
+      ).error?.message,
     ).toEqual('Missing return.')
   })
 
@@ -55,7 +56,7 @@ describe('Function Type Checking', () => {
     expect(
       mainRunner(
         'f := func(x int) int { if x == 1 { return "hi" } else { return 1 } }',
-      ).errorMessage,
+      ).error?.message,
     ).toEqual('Cannot use (string) as (int64) value in return statement.')
   })
 
@@ -63,7 +64,7 @@ describe('Function Type Checking', () => {
     expect(
       mainRunner(
         'f := func(x int) { if x == 1 { return 1 } else { return 1 } }',
-      ).errorMessage,
+      ).error?.message,
     ).toEqual('Too many return values\nhave (int64)\nwant ()')
   })
 })
@@ -127,7 +128,7 @@ describe('Function Execution tests', () => {
   test('Function assignment in loop and if', () => {
     expect(
       runCode(
-        `package mai
+        `package main
         import "fmt"
         func main() {
           f := func(x, y int) int {

--- a/tests/slice.test.ts
+++ b/tests/slice.test.ts
@@ -5,20 +5,20 @@ import { mainRunner } from './utility'
 describe('Slice Type Checking', () => {
   test('Slice literal must have the same type as the declared type.', () => {
     expect(
-      mainRunner('var a []int = []int{1, "wrong type", 3}').errorMessage,
+      mainRunner('var a []int = []int{1, "wrong type", 3}').error?.message,
     ).toEqual('Cannot use string as int64 value in slice literal.')
   })
 
   test('Slice indexing with non integer type should fail.', () => {
     expect(
-      mainRunner('var a []int = []int{1, 2, 3}; fmt.Println(a[1.2])')
-        .errorMessage,
+      mainRunner('var a []int = []int{1, 2, 3}; fmt.Println(a[1.2])').error
+        ?.message,
     ).toEqual('Invalid argument: Index has type float64 but must be an integer')
   })
 
   test('Slice len with too little arguments fails', () => {
     expect(
-      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len())').errorMessage,
+      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len())').error?.message,
     ).toEqual(
       'Invalid operation: not enough arguments for len (expected 1, found 0)',
     )
@@ -26,7 +26,8 @@ describe('Slice Type Checking', () => {
 
   test('Slice len with too many arguments fails', () => {
     expect(
-      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len(a, a))').errorMessage,
+      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len(a, a))').error
+        ?.message,
     ).toEqual(
       'Invalid operation: too many arguments for len (expected 1, found 2)',
     )
@@ -34,12 +35,12 @@ describe('Slice Type Checking', () => {
 
   test('Slice len with wrong type', () => {
     expect(
-      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len(1))').errorMessage,
+      mainRunner('a := []int{1, 2, 3, 4}; fmt.Println(len(1))').error?.message,
     ).toEqual('Invalid argument: (int64) for len')
   })
 
   test('Slicing invalid types should fail.', () => {
-    expect(mainRunner('a := 1; b := a[:]').errorMessage).toEqual(
+    expect(mainRunner('a := 1; b := a[:]').error?.message).toEqual(
       'Invalid operation: Cannot slice int64',
     )
   })
@@ -57,14 +58,14 @@ describe('Slice Execution', () => {
     expect(
       mainRunner(
         'var a []string = []string{"a", "b", "c"}\n fmt.Println(a[-1])',
-      ).errorMessage,
+      ).error?.message,
     ).toEqual('Execution Error: Index out of range [-1] with length 3')
   })
 
   test('Slice indexing with out of range index fails.', () => {
     expect(
       mainRunner('var a []string = []string{"a", "b", "c"}\n fmt.Println(a[3])')
-        .errorMessage,
+        .error?.message,
     ).toEqual('Execution Error: Index out of range [3] with length 3')
   })
 
@@ -105,7 +106,7 @@ describe('Slice Execution', () => {
   test('Slicing with out of bounds range should error.', () => {
     expect(
       mainRunner(`a := [4]int{0, 1, 2, 3}
-      b := a[4:5]`).errorMessage,
+      b := a[4:5]`).error?.message,
     ).toEqual('Execution Error: Slice bounds out of range')
   })
 })

--- a/tests/type.test.ts
+++ b/tests/type.test.ts
@@ -4,19 +4,19 @@ import { mainRunner } from './utility'
 
 describe('Assignment Type Checking', () => {
   test('Declaration', () => {
-    expect(mainRunner('var a int = 1.0').errorMessage).toEqual(
+    expect(mainRunner('var a int = 1.0').error?.message).toEqual(
       'Cannot use float64 as int64 in variable declaration',
     )
   })
 
   test('Short variable declaration', () => {
-    expect(mainRunner('a := 1; var b string = a').errorMessage).toEqual(
+    expect(mainRunner('a := 1; var b string = a').error?.message).toEqual(
       'Cannot use int64 as string in variable declaration',
     )
   })
 
   test('Assigment', () => {
-    expect(mainRunner('a := "hi"; a = 2').errorMessage).toEqual(
+    expect(mainRunner('a := "hi"; a = 2').error?.message).toEqual(
       'Cannot use int64 as string in assignment',
     )
   })
@@ -24,13 +24,13 @@ describe('Assignment Type Checking', () => {
 
 describe('Binary Operator Type Checking', () => {
   test('Add assign', () => {
-    expect(mainRunner('a := "hi"; a = 2 * "xyz"').errorMessage).toEqual(
+    expect(mainRunner('a := "hi"; a = 2 * "xyz"').error?.message).toEqual(
       'Invalid operation (mismatched types int64 and string)',
     )
   })
 
   test('Binary multiplication', () => {
-    expect(mainRunner('a := 1 * 1.0').errorMessage).toEqual(
+    expect(mainRunner('a := 1 * 1.0').error?.message).toEqual(
       'Invalid operation (mismatched types int64 and float64)',
     )
   })
@@ -38,7 +38,7 @@ describe('Binary Operator Type Checking', () => {
 
 describe('Miscellaneous Type Checking', () => {
   test('Variable shadowing', () => {
-    expect(mainRunner('a := 1; { a := 2.0; a = 1 }').errorMessage).toEqual(
+    expect(mainRunner('a := 1; { a := 2.0; a = 1 }').error?.message).toEqual(
       'Cannot use int64 as float64 in assignment',
     )
   })

--- a/tests/waitGroup.test.ts
+++ b/tests/waitGroup.test.ts
@@ -11,7 +11,9 @@ describe('Wait Group Type Checking', () => {
       var a sync.WaitGroup
     }
     `
-    expect(runCode(code, 2048).errorMessage).toEqual('Variable sync not found')
+    expect(runCode(code, 2048).error?.message).toEqual(
+      'Variable sync not found',
+    )
   })
 
   test('Assinging a variable of another type to WaitGroup should fail.', () => {
@@ -22,7 +24,7 @@ describe('Wait Group Type Checking', () => {
       var a sync.WaitGroup = "hello"
     }
     `
-    expect(runCode(code, 2048).errorMessage).toEqual(
+    expect(runCode(code, 2048).error?.message).toEqual(
       'Cannot use string as sync.WaitGroup in variable declaration',
     )
   })
@@ -36,7 +38,7 @@ describe('Wait Group Type Checking', () => {
       a.Add(1, 2)
     }
     `
-    expect(runCode(code, 2048).errorMessage).toEqual(
+    expect(runCode(code, 2048).error?.message).toEqual(
       'Too many arguments in function call\nhave (int64, int64)\nwant (int64)',
     )
   })
@@ -52,7 +54,7 @@ describe('Wait Group Execution', () => {
       a.Add(-5)
     }
     `
-    expect(runCode(code, 2048).errorMessage).toEqual(
+    expect(runCode(code, 2048).error?.message).toEqual(
       'Execution Error: sync: negative WaitGroup counter.',
     )
   })
@@ -68,7 +70,7 @@ describe('Wait Group Execution', () => {
       a.Done()
     }
     `
-    expect(runCode(code, 2048).errorMessage).toEqual(
+    expect(runCode(code, 2048).error?.message).toEqual(
       'Execution Error: sync: negative WaitGroup counter.',
     )
   })


### PR DESCRIPTION
This PR adds location information to tokens (where they start and end). This lets us highlight the token in the code that threw the compile error.

<img width="836" alt="Screenshot 2024-04-15 at 2 43 27 AM" src="https://github.com/huajun07/go-virtual-machine/assets/30954848/fb321696-9847-4c34-9e21-c3bbba74e92f">

Implementation:
=====
- A token's `.compile` method has been renamed `.compileUnchecked`, and a new method `.compile` is added. `compile` wraps `compileUnchecked` in a try catch block, such that it rethrows any error from its children tokens, or creates a new CompileError with its own location if it errors.
- The error returned from running code has been updated to be more detailed, to show whether the error is syntax / compile / runtime error.
- On the frontend, if we get a CompileError as the error, then we highlight from the starting till ending lines of the token responsible for the error.

Limitations:
=====
- There are some higher order functions in the parser file that makes it difficult to get the correct location. For example, in the code below, the error is (I think) correctly thrown from the BinaryOperator token, which means the 3 lines of `1 + "a"` should be highlighted. However, the parser sets the location of the entire BinaryOperator token as the `+` location. Since the information still looks sufficiently useful, this bug is low priority for now, and may not be fixed.
<img width="836" alt="Screenshot 2024-04-15 at 2 47 41 AM" src="https://github.com/huajun07/go-virtual-machine/assets/30954848/493798b0-1366-401c-9316-bff91d49ae39">
