### PR TITLE
feat: support comments

### DIFF
--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -68,7 +68,7 @@ start = _ @SourceFile _
 
 //* =============== Whitespace ===============
 // By convention, _ is used to eat up whitespace.
-_ = [ \t\r\n]*
+_ = ([ \t\r\n] / comment) *
 
 
 
@@ -93,7 +93,8 @@ hex_digit     = [0-9a-fA-F]
 
 
 //* =============== Lexical Elements ===============
-//! TODO (P4): Support comments.
+comment = "//" unicode_char* newline
+        / "/*" (!"*/" .)* "*/"
 
 //* Identifiers
 identifier = iden:$(letter (letter / unicode_digit)*) &{ return IdentifierToken.isValidIdentifier(iden) }

--- a/tests/comment.test.ts
+++ b/tests/comment.test.ts
@@ -19,7 +19,7 @@ describe('Comments Tests', () => {
         comment */
         /**/
         //
-        Println(/* comment in middle of code */a)
+        fmt.Println(/* comment in middle of code */a)
     }
     `
     expect(runCode(code, 2048).output).toEqual('3\n')

--- a/tests/comment.test.ts
+++ b/tests/comment.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+
+import { runCode } from '../src/virtual-machine'
+
+describe('Comments Tests', () => {
+  test('Comments are correctly ignored', () => {
+    const code = `
+    package main
+    // comments in global
+    import "fmt"
+    /*
+    multiline
+    comments in global
+    */
+
+    func main() {
+        a := 1 + 2 // comment at end of line
+        /* multiline
+        comment */
+        /**/
+        //
+        Println(/* comment in middle of code */a)
+    }
+    `
+    expect(runCode(code, 2048).output).toEqual('3\n')
+  })
+})


### PR DESCRIPTION
This is a small PR that adds support for comments. They are parsed as whitespace and ignored.

Golang supports two types of comments, which we implement:
- Line comments of the form `// this is a comment`.
- General comments of the form `/* this is a comment */` that can stretch across multiple lines.
