### PR TITLE
feat: visual code segments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@emotion/styled": "^11.11.0",
         "@uiw/codemirror-extensions-zebra-stripes": "^4.20.2",
         "@uiw/codemirror-theme-github": "^4.20.2",
-        "@uiw/react-codemirror": "^4.20.2",
+        "@uiw/react-codemirror": "^4.21.25",
         "axios": "^1.4.0",
         "cytoscape-cola": "^2.5.1",
         "d3-selection": "^3.0.0",
@@ -6361,9 +6361,9 @@
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.21.24",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.24.tgz",
-      "integrity": "sha512-TJYKlPxNAVJNclW1EGumhC7I02jpdMgBon4jZvb5Aju9+tUzS44IwORxUx8BD8ZtH2UHmYS+04rE3kLk/BtnCQ==",
+      "version": "4.21.25",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.25.tgz",
+      "integrity": "sha512-eeUKlmEE8aSoSgelS8OR2elcPGntpRo669XinAqPCLa0eKorT2B0d3ts+AE+njAeGk744tiyAEbHb2n+6OQmJw==",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -6428,15 +6428,15 @@
       }
     },
     "node_modules/@uiw/react-codemirror": {
-      "version": "4.21.24",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.24.tgz",
-      "integrity": "sha512-8zs5OuxbhikHocHBsVBMuW1vqlv4ccZAkt4rFwr7ebLP2Q6RwHsjpsR9GeGyAigAqonKRoeHugqF78UMrkaTgg==",
+      "version": "4.21.25",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.25.tgz",
+      "integrity": "sha512-mBrCoiffQ+hbTqV1JoixFEcH7BHXkS3PjTyNH7dE8Gzf3GSBRazhtSM5HrAFIiQ5FIRGFs8Gznc4UAdhtevMmw==",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/state": "^6.1.1",
         "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.21.24",
+        "@uiw/codemirror-extensions-basic-setup": "4.21.25",
         "codemirror": "^6.0.0"
       },
       "funding": {
@@ -26130,9 +26130,9 @@
       }
     },
     "@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.21.24",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.24.tgz",
-      "integrity": "sha512-TJYKlPxNAVJNclW1EGumhC7I02jpdMgBon4jZvb5Aju9+tUzS44IwORxUx8BD8ZtH2UHmYS+04rE3kLk/BtnCQ==",
+      "version": "4.21.25",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.21.25.tgz",
+      "integrity": "sha512-eeUKlmEE8aSoSgelS8OR2elcPGntpRo669XinAqPCLa0eKorT2B0d3ts+AE+njAeGk744tiyAEbHb2n+6OQmJw==",
       "requires": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -26168,15 +26168,15 @@
       }
     },
     "@uiw/react-codemirror": {
-      "version": "4.21.24",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.24.tgz",
-      "integrity": "sha512-8zs5OuxbhikHocHBsVBMuW1vqlv4ccZAkt4rFwr7ebLP2Q6RwHsjpsR9GeGyAigAqonKRoeHugqF78UMrkaTgg==",
+      "version": "4.21.25",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.21.25.tgz",
+      "integrity": "sha512-mBrCoiffQ+hbTqV1JoixFEcH7BHXkS3PjTyNH7dE8Gzf3GSBRazhtSM5HrAFIiQ5FIRGFs8Gznc4UAdhtevMmw==",
       "requires": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/state": "^6.1.1",
         "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.21.24",
+        "@uiw/codemirror-extensions-basic-setup": "4.21.25",
         "codemirror": "^6.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@emotion/styled": "^11.11.0",
     "@uiw/codemirror-extensions-zebra-stripes": "^4.20.2",
     "@uiw/codemirror-theme-github": "^4.20.2",
-    "@uiw/react-codemirror": "^4.20.2",
+    "@uiw/react-codemirror": "^4.21.25",
     "axios": "^1.4.0",
     "cytoscape-cola": "^2.5.1",
     "d3-selection": "^3.0.0",

--- a/src/frontend/components/CodeIDE/CodeIDE.tsx
+++ b/src/frontend/components/CodeIDE/CodeIDE.tsx
@@ -1,21 +1,85 @@
+import { useEffect, useRef } from 'react'
 import { useColorModeValue } from '@chakra-ui/react'
 import { go } from '@codemirror/lang-go'
-import { Prec } from '@codemirror/state'
-import { keymap } from '@codemirror/view'
+import { Prec, StateEffect, StateField } from '@codemirror/state'
+import { Decoration, keymap } from '@codemirror/view'
 import { zebraStripes } from '@uiw/codemirror-extensions-zebra-stripes'
 import { githubDark, githubLight } from '@uiw/codemirror-theme-github'
-import CodeMirror, { EditorSelection } from '@uiw/react-codemirror'
+import CodeMirror, { EditorSelection, EditorView } from '@uiw/react-codemirror'
+
+import { useExecutionStore } from '../../stores'
 
 interface codeIDEProps {
   code: string
   setCode: (code: string) => void
   lineHighlight?: (number | number[])[]
   run: () => void
+  editable: boolean
 }
 
 export const CodeIDE = (props: codeIDEProps) => {
+  const { location } = useExecutionStore((state) => ({
+    location: state.location,
+  }))
   const placeholder = 'Enter your go code here!'
   const { code, setCode, lineHighlight } = props
+  const editorView = useRef<EditorView | null>(null)
+  // const [loaded, setLoaded] = useState(false)
+
+  // code mirror effect that you will use to define the effect you want (the decoration)
+  const highlight_effect = StateEffect.define<{ from: number; to: number }>({
+    map: ({ from, to }, change) => ({
+      from: change.mapPos(from),
+      to: change.mapPos(to),
+    }),
+  })
+
+  const highlightField = StateField.define({
+    create() {
+      return Decoration.none
+    },
+    update(highlights, tr) {
+      highlights = highlights.map(tr.changes)
+      for (const e of tr.effects)
+        if (e.is(highlight_effect)) {
+          highlights = highlights.update({
+            add: [highlightMark.range(e.value.from, e.value.to)],
+          })
+        }
+      return highlights
+    },
+    provide: (f) => EditorView.decorations.from(f),
+  })
+
+  const highlightMark = Decoration.mark({ class: 'cm-highlighted' })
+  const highlightTheme = EditorView.baseTheme({
+    '.cm-highlighted': {
+      background: useColorModeValue('#F9ffab', '#7c05a2'),
+      fontWeight: 'bold',
+    },
+  })
+
+  useEffect(() => {
+    if (editorView.current && location) {
+      const effects: StateEffect<unknown>[] = [
+        highlight_effect.of({
+          from: location.start.offset,
+          to: location.end.offset,
+        }),
+      ]
+      effects.push(
+        StateEffect.appendConfig.of([highlightField, highlightTheme]),
+      )
+      editorView.current.dispatch({ effects })
+    }
+  }, [
+    location,
+    highlightField,
+    highlightTheme,
+    highlightMark,
+    highlight_effect,
+  ])
+
   return (
     <CodeMirror
       value={code}
@@ -23,6 +87,16 @@ export const CodeIDE = (props: codeIDEProps) => {
       placeholder={placeholder}
       autoFocus={true}
       width="100%"
+      style={props.editable ? {} : { cursor: 'not-allowed' }}
+      editable={props.editable}
+      readOnly={!props.editable}
+      basicSetup={{
+        highlightActiveLineGutter: props.editable,
+        highlightActiveLine: props.editable,
+      }}
+      onCreateEditor={(view) => {
+        editorView.current = view
+      }}
       extensions={[
         zebraStripes({
           lineNumber: lineHighlight,

--- a/src/frontend/components/CodeIDE/CodeIDEButtons.tsx
+++ b/src/frontend/components/CodeIDE/CodeIDEButtons.tsx
@@ -1,4 +1,5 @@
 import { AiFillCaretRight } from 'react-icons/ai'
+import { MdEdit } from 'react-icons/md'
 import {
   Box,
   Button,
@@ -16,6 +17,7 @@ import {
 
 interface CodeIDEButtonProps {
   isDisabled: boolean
+  editing: boolean
   toggleMode: () => void
   heapsize: number
   setHeapsize: (x: number) => void
@@ -49,13 +51,13 @@ export const CodeIDEButtons = (props: CodeIDEButtonProps) => {
           <Button
             marginRight="10px"
             size="sm"
-            rightIcon={<Icon as={AiFillCaretRight} />}
+            rightIcon={<Icon as={props.editing ? AiFillCaretRight : MdEdit} />}
             colorScheme="blue"
             variant="solid"
             onClick={props.toggleMode}
             isDisabled={props.isDisabled}
           >
-            {'Run'}
+            {props.editing ? 'Run' : 'Edit'}
           </Button>
         </Tooltip>
       </Flex>

--- a/src/frontend/stores/executionStore.ts
+++ b/src/frontend/stores/executionStore.ts
@@ -2,6 +2,7 @@ import { shallow } from 'zustand/shallow'
 import { createWithEqualityFn } from 'zustand/traditional'
 
 import { ContextInfo, StateInfo } from '../../virtual-machine/executor/debugger'
+import { TokenLocation } from '../../virtual-machine/parser/tokens'
 
 export interface ExecutionState {
   currentStep: number
@@ -11,6 +12,8 @@ export interface ExecutionState {
   cur_data: ContextInfo[]
   output: string
   setOutput: (output: string) => void
+  setLocation: (location: TokenLocation | null) => void
+  location: TokenLocation | null
 }
 
 const defaultValues = {
@@ -18,6 +21,7 @@ const defaultValues = {
   data: [],
   cur_data: [],
   output: '',
+  location: null,
 }
 
 /**
@@ -41,6 +45,7 @@ export const createExecutionStore = (initialState: Partial<ExecutionState>) => {
             currentStep: step,
             cur_data: get().data[step].contexts,
             output: get().data[step].output,
+            location: get().data[step].location,
           })
         }
       },
@@ -56,6 +61,9 @@ export const createExecutionStore = (initialState: Partial<ExecutionState>) => {
       },
       setOutput: (output: string) => {
         set({ output })
+      },
+      setLocation: (location: TokenLocation | null) => {
+        set({ location })
       },
       ...initialState,
     }),

--- a/src/virtual-machine/compiler/index.ts
+++ b/src/virtual-machine/compiler/index.ts
@@ -12,6 +12,7 @@ export class CompileError extends Error {
 
 export class Compiler {
   instructions: Instruction[] = []
+  symbols: (TokenLocation | null)[] = []
   context = new CompileContext()
   type_environment = new TypeEnvironment()
 
@@ -28,7 +29,10 @@ export class Compiler {
 const compile_tokens = (token: Token) => {
   const compiler = new Compiler()
   compiler.compile_program(token)
-  return compiler.instructions
+  return {
+    instructions: compiler.instructions,
+    symbols: compiler.symbols,
+  }
 }
 
 export { compile_tokens }

--- a/src/virtual-machine/compiler/typing/packages.ts
+++ b/src/virtual-machine/compiler/typing/packages.ts
@@ -69,6 +69,7 @@ export const builtinPackages = {
       new LoadVariableInstruction(frame_idx, var_idx, 'fmt'),
       new StoreInstruction(),
     )
+    compiler.symbols.push(...Array(4).fill(null))
     return pkg
   },
   sync: (compiler: Compiler): Type => {

--- a/src/virtual-machine/executor/index.ts
+++ b/src/virtual-machine/executor/index.ts
@@ -1,13 +1,15 @@
 import { Instruction } from '../compiler/instructions'
+import { TokenLocation } from '../parser/tokens'
 
 import { Process } from './process'
 
 const execute_instructions = (
   instrs: Instruction[],
   heapsize: number,
+  symbols: (TokenLocation | null)[],
   visualisation = false,
 ) => {
-  const process = new Process(instrs, heapsize, visualisation)
+  const process = new Process(instrs, heapsize, symbols, visualisation)
   return process.start()
 }
 

--- a/src/virtual-machine/heap/types/fmt.ts
+++ b/src/virtual-machine/heap/types/fmt.ts
@@ -17,6 +17,10 @@ export class PkgNode extends BaseNode {
   static default(heap: Heap): PkgNode {
     return PkgNode.create(heap)
   }
+
+  override toString(): string {
+    return 'PKG'
+  }
 }
 
 /**

--- a/src/virtual-machine/index.ts
+++ b/src/virtual-machine/index.ts
@@ -1,7 +1,7 @@
 import { Instruction } from './compiler/instructions'
 import { StateInfo } from './executor/debugger'
 import parser from './parser/parser'
-import { SourceFileToken } from './parser/tokens'
+import { SourceFileToken, TokenLocation } from './parser/tokens'
 import { compile_tokens, CompileError } from './compiler'
 import { execute_instructions } from './executor'
 
@@ -46,8 +46,11 @@ const runCode = (
 
   // Compilation.
   let instructions: Instruction[] = []
+  let symbols: (TokenLocation | null)[] = []
   try {
-    instructions = compile_tokens(tokens)
+    const temp = compile_tokens(tokens)
+    instructions = temp.instructions
+    symbols = temp.symbols
     console.log(instructions)
   } catch (err) {
     const message = (err as CompileError).message
@@ -64,7 +67,12 @@ const runCode = (
   }
 
   // Execution.
-  const result = execute_instructions(instructions, heapsize, visualisation)
+  const result = execute_instructions(
+    instructions,
+    heapsize,
+    symbols,
+    visualisation,
+  )
   if (result.errorMessage) {
     console.warn(result.errorMessage)
     return {

--- a/src/virtual-machine/parser/parser.peggy
+++ b/src/virtual-machine/parser/parser.peggy
@@ -339,10 +339,10 @@ UnaryExpr  = PrimaryExpr /
 // Operators are parsed into a function, that can be applied on operands to construct a token.
 rel_op      = "==" { return BinaryOperator.fromSource(location(), "equal") } /
               "!=" { return BinaryOperator.fromSource(location(), "not_equal") } /
-              "<" !"-" { return BinaryOperator.fromSource(location(), "less") } /
               "<=" { return BinaryOperator.fromSource(location(), "less_or_equal") } /
-              ">" { return BinaryOperator.fromSource(location(), "greater") } /
-              ">=" { return BinaryOperator.fromSource(location(), "greater_or_equal") }
+              ">=" { return BinaryOperator.fromSource(location(), "greater_or_equal") } /
+              "<" !"-" { return BinaryOperator.fromSource(location(), "less") } /
+              ">" { return BinaryOperator.fromSource(location(), "greater") } 
 add_op      = "+" !"+" { return BinaryOperator.fromSource(location(), "sum") } /
               "-" !"-" { return BinaryOperator.fromSource(location(), "difference") } /
               "|" !"|" { return BinaryOperator.fromSource(location(), "bitwise_or") } /

--- a/src/virtual-machine/parser/tokens/base.ts
+++ b/src/virtual-machine/parser/tokens/base.ts
@@ -1,4 +1,5 @@
 import { CompileError, Compiler } from '../../compiler'
+import { Instruction } from '../../compiler/instructions'
 import { Type } from '../../compiler/typing'
 
 export type TokenLocation = {
@@ -10,6 +11,11 @@ export abstract class Token {
   constructor(public type: string, public sourceLocation: TokenLocation) {}
 
   abstract compileUnchecked(compiler: Compiler): Type
+
+  pushInstruction(compiler: Compiler, ...instr: Instruction[]) {
+    compiler.instructions.push(...instr)
+    compiler.symbols.push(...Array(instr.length).fill(this.sourceLocation))
+  }
 
   compile(compiler: Compiler): Type {
     try {

--- a/src/virtual-machine/parser/tokens/block.ts
+++ b/src/virtual-machine/parser/tokens/block.ts
@@ -20,7 +20,7 @@ export class BlockToken extends Token {
   override compileUnchecked(compiler: Compiler): Type {
     compiler.context.push_env()
     const block_instr = new BlockInstruction(this.name)
-    compiler.instructions.push(block_instr)
+    this.pushInstruction(compiler, block_instr)
     compiler.type_environment = compiler.type_environment.extend()
     let hasReturn = false
     for (const sub_token of this.statements) {
@@ -39,7 +39,7 @@ export class BlockToken extends Token {
     compiler.type_environment = compiler.type_environment.pop()
     compiler.context.pop_env()
 
-    compiler.instructions.push(new ExitBlockInstruction())
+    this.pushInstruction(compiler, new ExitBlockInstruction())
 
     return blockType
   }

--- a/src/virtual-machine/parser/tokens/declaration.ts
+++ b/src/virtual-machine/parser/tokens/declaration.ts
@@ -36,10 +36,11 @@ export class FunctionDeclarationToken extends Token {
       this.func.signature.compile(compiler),
     )
     this.func.compile(compiler)
-    compiler.instructions.push(
+    this.pushInstruction(
+      compiler,
       new LoadVariableInstruction(frame_idx, var_idx, this.name.identifier),
     )
-    compiler.instructions.push(new StoreInstruction())
+    this.pushInstruction(compiler, new StoreInstruction())
     return new NoType()
   }
 }
@@ -63,10 +64,11 @@ export class ShortVariableDeclarationToken extends DeclarationToken {
       const [frame_idx, var_idx] = compiler.context.env.declare_var(var_name)
       const expressionType = expr.compile(compiler)
       compiler.type_environment.addType(var_name, expressionType)
-      compiler.instructions.push(
+      this.pushInstruction(
+        compiler,
         new LoadVariableInstruction(frame_idx, var_idx, var_name),
       )
-      compiler.instructions.push(new StoreInstruction())
+      this.pushInstruction(compiler, new StoreInstruction())
     }
     return new NoType()
   }
@@ -118,10 +120,11 @@ export class VariableDeclarationToken extends DeclarationToken {
           )
         }
         compiler.type_environment.addType(identifier, expressionType)
-        compiler.instructions.push(
+        this.pushInstruction(
+          compiler,
           new LoadVariableInstruction(frame_idx, var_idx, identifier),
         )
-        compiler.instructions.push(new StoreInstruction())
+        this.pushInstruction(compiler, new StoreInstruction())
       }
     } else {
       // Variables are uninitialized, but their type is given.
@@ -166,10 +169,11 @@ export class ConstantDeclarationToken extends DeclarationToken {
         )
       }
       compiler.type_environment.addType(var_name, expressionType)
-      compiler.instructions.push(
+      this.pushInstruction(
+        compiler,
         new LoadVariableInstruction(frame_idx, var_idx, var_name),
       )
-      compiler.instructions.push(new StoreInstruction())
+      this.pushInstruction(compiler, new StoreInstruction())
     }
     return new NoType()
   }

--- a/src/virtual-machine/parser/tokens/identifier.ts
+++ b/src/virtual-machine/parser/tokens/identifier.ts
@@ -42,7 +42,8 @@ export class IdentifierToken extends Token {
 
   override compileUnchecked(compiler: Compiler): Type {
     const [frame_idx, var_idx] = compiler.context.env.find_var(this.identifier)
-    compiler.instructions.push(
+    this.pushInstruction(
+      compiler,
       new LoadVariableInstruction(frame_idx, var_idx, this.identifier),
     )
     return compiler.type_environment.get(this.identifier)

--- a/src/virtual-machine/parser/tokens/operator.ts
+++ b/src/virtual-machine/parser/tokens/operator.ts
@@ -44,14 +44,15 @@ export class UnaryOperator extends Operator {
       if (!(expressionType instanceof ChannelType))
         throw Error('Receive Expression not chan')
       const recvType = expressionType.element
-      compiler.instructions.push(new LoadDefaultInstruction(recvType))
-      compiler.instructions.push(
+      this.pushInstruction(compiler, new LoadDefaultInstruction(recvType))
+      this.pushInstruction(
+        compiler,
         new LoadChannelReqInstruction(true, compiler.instructions.length + 2),
       )
-      compiler.instructions.push(new TryChannelReqInstruction())
+      this.pushInstruction(compiler, new TryChannelReqInstruction())
       return recvType
     } else {
-      compiler.instructions.push(new UnaryInstruction(this.name))
+      this.pushInstruction(compiler, new UnaryInstruction(this.name))
       return expressionType
     }
   }
@@ -82,7 +83,7 @@ export class BinaryOperator extends Operator {
         `Invalid operation (mismatched types ${leftType} and ${rightType})`,
       )
     }
-    compiler.instructions.push(new BinaryInstruction(this.name))
+    this.pushInstruction(compiler, new BinaryInstruction(this.name))
     const logical_operators = [
       'equal',
       'not_equal',

--- a/src/virtual-machine/parser/tokens/source_file.ts
+++ b/src/virtual-machine/parser/tokens/source_file.ts
@@ -26,7 +26,7 @@ export class SourceFileToken extends Token {
   override compileUnchecked(compiler: Compiler): Type {
     // Setup.
     const global_block = new BlockInstruction('GLOBAL')
-    compiler.instructions.push(global_block)
+    this.pushInstruction(compiler, global_block)
     compiler.context.push_env()
     compiler.type_environment = compiler.type_environment.extend()
 
@@ -43,10 +43,11 @@ export class SourceFileToken extends Token {
 
     // Call main function.
     const [frame_idx, var_idx] = compiler.context.env.find_var('main')
-    compiler.instructions.push(
+    this.pushInstruction(
+      compiler,
       new LoadVariableInstruction(frame_idx, var_idx, 'main'),
     )
-    compiler.instructions.push(new CallInstruction(0))
+    this.pushInstruction(compiler, new CallInstruction(0))
     const vars = compiler.context.env.get_frame()
     global_block.set_frame(
       vars.map((name) => compiler.type_environment.get(name)),
@@ -71,7 +72,8 @@ export class SourceFileToken extends Token {
     for (const constant of constants) {
       const { name, loadInstruction, type } = constant
       const [frame_idx, var_idx] = compiler.context.env.declare_var(name)
-      compiler.instructions.push(
+      this.pushInstruction(
+        compiler,
         loadInstruction,
         new LoadVariableInstruction(frame_idx, var_idx, name),
         new StoreInstruction(),


### PR DESCRIPTION
# Feature
- Make use of `TokenLocation` to highlight current active code segment in visualisation
- Add `symbols` field in `Compiler` class to store `TokenLocation[]`
- Replaced all `compiler.instructions.push` with `Token::pushInstruction` to get access to token's `TokenLocation`
- Added back editing mode to prevent editing while code segment is being highlighted

# Bug Fixes
- Ordering of operations in `rel_op` in parser
- Check for duplicate contexts in visual states
- Make current active context PC to reflect instruction that was just ran (instead of the next instruction), as it is more intuitive
- When blocking for wait group, add context to blocked list and when unblocking from wati group remove from blocked list