### PR TITLE
fix: array m&s bug

### DIFF
--- a/src/frontend/components/IO/TextIDE.tsx
+++ b/src/frontend/components/IO/TextIDE.tsx
@@ -14,6 +14,7 @@ export const TextIDE = (props: textIDEProps) => {
     <CodeMirror
       value={props.text}
       height="100%"
+      maxHeight="700px"
       style={{
         height: '100%',
         ...(!props.editable && { cursor: 'not-allowed' }),

--- a/src/virtual-machine/heap/types/array.ts
+++ b/src/virtual-machine/heap/types/array.ts
@@ -13,6 +13,7 @@ export class ArrayNode extends BaseNode {
     const addr = heap.allocate(2 + length)
     heap.set_tag(addr, TAG.ARRAY)
     heap.memory.set_number(length, addr + 1)
+    for (let i = 0; i < length; i++) heap.memory.set_number(-1, addr + i + 2)
     return new ArrayNode(heap, addr)
   }
 
@@ -53,9 +54,7 @@ export class ArrayNode extends BaseNode {
   }
 
   override get_children(): number[] {
-    return [...Array(this.length()).keys()].map((x) =>
-      this.heap.get_child(this.addr + 2, x),
-    )
+    return [...Array(this.length()).keys()].map((x) => this.get_child(x))
   }
 
   override toString(): string {

--- a/src/virtual-machine/heap/types/array.ts
+++ b/src/virtual-machine/heap/types/array.ts
@@ -30,6 +30,7 @@ export class ArrayNode extends BaseNode {
     heap.set_tag(addr, TAG.ARRAY)
     heap.memory.set_number(length, addr + 1)
     heap.temp_push(addr)
+    for (let i = 0; i < length; i++) heap.memory.set_number(-1, addr + i + 2)
     for (let i = 0; i < length; i++) {
       heap.memory.set_word(defaultCreator(heap), addr + 2 + i)
     }

--- a/tests/channel.test.ts
+++ b/tests/channel.test.ts
@@ -66,7 +66,8 @@ describe('Channel Tests', () => {
         }()
          for i:=0; i < 5; i++{}
          fmt.Println("done")
-         c2 <- "stop"`)
+         c2 <- "stop"
+         for i:=0; i < 100; i++{}`)
       .output?.trim()
       .split('\n')
     let done = false
@@ -112,7 +113,8 @@ describe('Channel Tests', () => {
            fmt.Println("Read 2 1")
           }
          }
-        }()`)
+        }()
+        for i:=0; i < 100; i++{}`)
       .output?.trim()
       .split('\n')
     const arr1: number[] = [],
@@ -145,7 +147,8 @@ describe('Channel Tests', () => {
       for i:=0;i < 100;i++ {
       }
       fmt.Println("done1")
-      <-c1`).output,
+      <-c1
+      for i:=0; i < 100; i++{}`).output,
     ).toEqual('done1\ndone2\n')
   })
 })


### PR DESCRIPTION
# Fix
- When `ArrayNode` is created, the elements are undefined, thus if mark and sweep is called, it could cause errors.

# Feature
- Check if main thread has completed, and if so terminate